### PR TITLE
Enforce Host in Store Endpoint matches the DSN's Host

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ python3 event.py
 **STEP2**  
 ```
 go run event-to-sentry.go
+go run event-to-sentry.go --id=<id>
 go run event-to-sentry.go --all
 
 python3 event-to-sentry.py
@@ -72,11 +73,12 @@ https://develop.sentry.dev/sdk/event-payloads/ for what a sdk event looks like. 
 
 ## Todo
 
+- AM transactions
+- Android errors/crashes/sessions
+
 - sentry-cli for Release for js events from Database, so they're minified
 - sentry-cli should create a release and associate commits, use a Release# that relates to day of the week or day/month/year
 - when loading events from database, should be able to set this same day/month/year as the release, so it'll get associated in Sentry.io
-
-- Android errors/crashes/sessions
 
 - write a proxy.go, but make sure Mobile stuff works in proxy.py first
 - event-to-sentry.go var DATABASE_PATH

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ https://develop.sentry.dev/sdk/event-payloads/ for what a sdk event looks like. 
 - sentry-cli should create a release and associate commits, use a Release# that relates to day of the week or day/month/year
 - when loading events from database, should be able to set this same day/month/year as the release, so it'll get associated in Sentry.io
 
+- proxy.py platform, eventType instead of name, type. for now, re-purpose 'name' as 'platform' and 'type' as 'eventType'
 - write a proxy.go, but make sure Mobile stuff works in proxy.py first
 - event-to-sentry.go var DATABASE_PATH
 - improve use of log.Fatal vs panic, error handling

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ python3 event-to-sentry.py <id>
 See your event in Sentry at `localhost:9000`
 
 **OPTIONAL**  
-Cronjob on your Macbook that sends events in the background. Still needs sentry-cli usage for setting the release, and then event-to-sentry.go to use that same release.
+Cronjob on Macbook that sends events in the background
 ```
 # crontab -e
 1-59 * * * * cd /home/wcap/thinkocapo/event-maker/ && ./event-to-sentry
@@ -57,17 +57,18 @@ Cronjob on your Macbook that sends events in the background. Still needs sentry-
 ```
 
 ## Notes
-There are 3 modified DSN's in `event.py` that correspond to the 3 different endpoints in `flask/proxy.py` which you can hit.`
+See `python/event.py` for how to construct the 3 'MODIFIED' DSN's which decide which of the 3 endpoints in `flask/proxy.py` which you can hit.
 
-`python test/db.py` and `go run test/db.go` are for showing total row count and most recent event.
+`python3 test/db.py` and `go run test/db.go` are for showing total row count and most recent event.
 
 The timestamp from `go run event-to-sentry.go` is sometimes earlier than today's date
 
+
+Borrowed code from: getsentry/sentry-python, getsentry/sentry-go, goreplay
+
 https://develop.sentry.dev/sdk/store for info on what the real Sentry endpoints are doing
 
-This repo borrowed code from: getsentry/sentry-python's transport.py, core_api.py, event_manager.py, and getsentry/sentry-go
-
-[/img/example-payload.png](./img/example-payload.png) from a sentry sdk event
+https://develop.sentry.dev/sdk/event-payloads/ for what a sdk event looks like. Here's [/img/example-payload.png](./img/example-payload.png) from javascript
 
 ## Todo
 

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -158,11 +158,14 @@ func python(bodyBytesCompressed []byte, headers []byte) {
 func main() {
 	defer db.Close()
 	
+	query := ""
+	if (*id == "") {
+		query = "SELECT * FROM events ORDER BY id DESC"
+	} else {
+		query = strings.ReplaceAll("SELECT * FROM events WHERE id=?", "?", *id)
+	}
 
-	rows, err := db.Query(strings.ReplaceAll("SELECT * FROM events WHERE id=?", "?", *id))
-
-	// ORIGINAL
-	// rows, err := db.Query("SELECT * FROM events ORDER BY id DESC")
+	rows, err := db.Query(query)
 	
 	if err != nil {
 		fmt.Println("Failed to load rows", err)

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -33,16 +33,13 @@ var (
 )
 
 type DSN struct { 
+	host string
 	rawurl string
 	key string
 	projectId string
 }
-func (d DSN) storeEndpoint() string {
-	// return strings.Join([]string{"http://sentry.io/api/",d.projectId,"/store/?sentry_key=",d.key,"&sentry_version=7"}, "")
-	return strings.Join([]string{"http://localhost:9000/api/",d.projectId,"/store/?sentry_key=",d.key,"&sentry_version=7"}, "")
-}
-func newDSN(rawurl string) (*DSN) {
-	// TODO if 'sentry.io' in url then host := sentry.io else host := localhost:9000, and update storeEndpoint() w/ 'host'
+
+func parseDSN(rawurl string) (*DSN) {
 	key := strings.Split(rawurl, "@")[0][7:]
 
 	uri, err := url.Parse(rawurl)
@@ -54,13 +51,28 @@ func newDSN(rawurl string) (*DSN) {
 		log.Fatal("missing projectId in dsn")
 	}
 	projectId := uri.Path[idx+1:]
-	fmt.Println("> PROJECTID", projectId)
+	fmt.Println("> DSN projectId", projectId)
+
+	var host string
+	if (strings.Contains(rawurl, "ingest.sentry.io")) {
+		host = fmt.Sprint("sentry.io")
+	}
+	if (strings.Contains(rawurl, "@localhost:")) {
+		host = fmt.Sprint("localhost:9000")
+	}
+	fmt.Println("> DSN host", host)
 	
 	return &DSN{
+		host,
 		rawurl,
 		key,
 		projectId,
 	}
+}
+
+// could make a DSN field called 'storeEndpoint' and use this function there to assign the value
+func (d DSN) storeEndpoint() string {
+	return strings.Join([]string{"http://",d.host,"/api/",d.projectId,"/store/?sentry_key=",d.key,"&sentry_version=7"}, "")
 }
 
 type Event struct {
@@ -81,10 +93,10 @@ func init() {
 	}
 
 	projects = make(map[string]*DSN)
-	projects["javascript"] = newDSN(os.Getenv("DSN_REACT"))
-	projects["python"] = newDSN(os.Getenv("DSN_PYTHON"))
-	// projects["javascript"] = newDSN(os.Getenv("DSN_REACT_SAAS"))
-	// projects["python"] = newDSN(os.Getenv("DSN_PYTHON_SAAS"))
+	projects["javascript"] = parseDSN(os.Getenv("DSN_REACT"))
+	projects["python"] = parseDSN(os.Getenv("DSN_PYTHON"))
+	// projects["javascript"] = parseDSN(os.Getenv("DSN_REACT_SAAS"))
+	// projects["python"] = parseDSN(os.Getenv("DSN_PYTHON_SAAS"))
 
 	all = flag.Bool("all", false, "send all events or 1 event from database")
 	id = flag.String("id", "", "id of event in sqlite database")

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -55,10 +55,10 @@ func parseDSN(rawurl string) (*DSN) {
 
 	var host string
 	if (strings.Contains(rawurl, "ingest.sentry.io")) {
-		host = fmt.Sprint("sentry.io")
+		host = "ingest.sentry.io" // works with "sentry.io" too
 	}
 	if (strings.Contains(rawurl, "@localhost:")) {
-		host = fmt.Sprint("localhost:9000")
+		host = "localhost:9000"
 	}
 	fmt.Println("> DSN host", host)
 	
@@ -72,7 +72,8 @@ func parseDSN(rawurl string) (*DSN) {
 
 // could make a DSN field called 'storeEndpoint' and use this function there to assign the value
 func (d DSN) storeEndpoint() string {
-	return strings.Join([]string{"http://",d.host,"/api/",d.projectId,"/store/?sentry_key=",d.key,"&sentry_version=7"}, "")
+	return fmt.Sprint("http://",d.host,"/api/",d.projectId,"/store/?sentry_key=",d.key,"&sentry_version=7")
+	// return strings.Join([]string{"http://",d.host,"/api/",d.projectId,"/store/?sentry_key=",d.key,"&sentry_version=7"}, "")
 }
 
 type Event struct {

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -24,6 +24,7 @@ var httpClient = &http.Client{}
 
 var (
 	all *bool
+	id *string
 	db *sql.DB
 	dsn DSN
 	SENTRY_URL string 
@@ -86,8 +87,11 @@ func init() {
 	// projects["python"] = newDSN(os.Getenv("DSN_PYTHON_SAAS"))
 
 	all = flag.Bool("all", false, "send all events or 1 event from database")
+	id = flag.String("id", "", "id of event in sqlite database")
 	flag.Parse()
 	fmt.Printf("> --all= %v\n", *all)
+	fmt.Printf("> --id= %v\n", *id)
+
 	
 	db, _ = sql.Open("sqlite3", "sqlite.db")
 }
@@ -154,13 +158,8 @@ func python(bodyBytesCompressed []byte, headers []byte) {
 func main() {
 	defer db.Close()
 	
-	id := "15"
-	//query := []string{"SELECT * FROM events WHERE id=", string(id)}
-	// rows, err := db.Query(strings.Join(query, ""))
-	// rows, err := db.Query("SELECT * FROM events WHERE id=16")
-	
-	// strconv.Itoa(i)
-	rows, err := db.Query(strings.ReplaceAll("SELECT * FROM events WHERE id=?", "?", id))
+
+	rows, err := db.Query(strings.ReplaceAll("SELECT * FROM events WHERE id=?", "?", *id))
 
 	// ORIGINAL
 	// rows, err := db.Query("SELECT * FROM events ORDER BY id DESC")

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -37,7 +37,8 @@ type DSN struct {
 	projectId string
 }
 func (d DSN) storeEndpoint() string {
-	return strings.Join([]string{"http://sentry.io/api/",d.projectId,"/store/?sentry_key=",d.key,"&sentry_version=7"}, "")
+	// return strings.Join([]string{"http://sentry.io/api/",d.projectId,"/store/?sentry_key=",d.key,"&sentry_version=7"}, "")
+	return strings.Join([]string{"http://localhost:9000/api/",d.projectId,"/store/?sentry_key=",d.key,"&sentry_version=7"}, "")
 }
 func newDSN(rawurl string) (*DSN) {
 	// TODO if 'sentry.io' in url then host := sentry.io else host := localhost:9000, and update storeEndpoint() w/ 'host'
@@ -79,10 +80,10 @@ func init() {
 	}
 
 	projects = make(map[string]*DSN)
-	// projects["javascript"] = newDSN(os.Getenv("DSN_REACT"))
-	// projects["python"] = newDSN(os.Getenv("DSN_PYTHON"))
-	projects["javascript"] = newDSN(os.Getenv("DSN_REACT_SAAS"))
-	projects["python"] = newDSN(os.Getenv("DSN_PYTHON_SAAS"))
+	projects["javascript"] = newDSN(os.Getenv("DSN_REACT"))
+	projects["python"] = newDSN(os.Getenv("DSN_PYTHON"))
+	// projects["javascript"] = newDSN(os.Getenv("DSN_REACT_SAAS"))
+	// projects["python"] = newDSN(os.Getenv("DSN_PYTHON_SAAS"))
 
 	all = flag.Bool("all", false, "send all events or 1 event from database")
 	flag.Parse()
@@ -152,8 +153,18 @@ func python(bodyBytesCompressed []byte, headers []byte) {
 
 func main() {
 	defer db.Close()
+	
+	id := "15"
+	//query := []string{"SELECT * FROM events WHERE id=", string(id)}
+	// rows, err := db.Query(strings.Join(query, ""))
+	// rows, err := db.Query("SELECT * FROM events WHERE id=16")
+	
+	// strconv.Itoa(i)
+	rows, err := db.Query(strings.ReplaceAll("SELECT * FROM events WHERE id=?", "?", id))
 
-	rows, err := db.Query("SELECT * FROM events ORDER BY id DESC")
+	// ORIGINAL
+	// rows, err := db.Query("SELECT * FROM events ORDER BY id DESC")
+	
 	if err != nil {
 		fmt.Println("Failed to load rows", err)
 	}
@@ -240,6 +251,6 @@ func addTimestamp(bodyInterface map[string]interface{}) map[string]interface{} {
 	timestamp1 := time.Now()
 	newTimestamp1 := timestamp1.Format("2006-01-02") + "T" + timestamp1.Format("15:04:05")
 	bodyInterface["timestamp"] = newTimestamp1 + ".118356Z"
-	fmt.Println("after ",bodyInterface["timestamp"])
+	fmt.Println("> after ",bodyInterface["timestamp"])
 	return bodyInterface
 }

--- a/python/proxy.py
+++ b/python/proxy.py
@@ -36,6 +36,7 @@ def sentryUrl(DSN):
     PROJECT_ID= DSN[-1:]
     # Must pass auth key in URL (not request headers) or else 403 CSRF error from Sentry
     # SENTRY ="http://localhost:9000/api/{}/store/?sentry_key=09aa0d909232457a8a6dfff118bac658&sentry_version=7".format(PROJECT_ID)
+    # TODO must update for http://sentry.io as well. or re-write proxy in Go 
     return "http://localhost:9000/api/%s/store/?sentry_key=%s&sentry_version=7" % (PROJECT_ID, KEY)
 
 # DATABASE - Must be full absolute path to sqlite database file
@@ -44,6 +45,7 @@ SQLITE = os.getenv('SQLITE')
 database = SQLITE or os.getcwd() + "/sqlite.db"
 print("> database", database)
 with sqlite3.connect(database) as db:
+    # TODO platform, eventType instead of name, type. for now, re-purpose 'name' as 'platform' and 'type' as 'eventType'
     cursor = db.cursor()
     cursor.execute(""" CREATE TABLE IF NOT EXISTS events (
                                             id integer PRIMARY KEY,
@@ -61,15 +63,7 @@ with sqlite3.connect(database) as db:
 def forward():
     print('> FORWARD')
 
-    """
-    TODO
-    The purpose of this function is to figure out what kind of event (javascript, python etc.) is being sent.
-    It'd be much more convenient to look at the ?sentry_key=<value> being passed and compare it against the DSN's in .env, to figure it out...
-    But sentry-python doesn't provide it in the URL :( only sentry-javascript does
-    # print('> request', request.base_url) # only shows ?sentry_key=<value> on the javascript events :/
-    # key=request.args['sentry_key'] # value only exists for jascript events, not python :/
-    My guess is Sentry.io doesn't need this in the query params anyways, because all it needs is the project Id '/2' which in our case we're abusing to define the proxy endpoint (not allowed to use letters, numbers only)
-    """
+    # TODO https://github.com/thinkocapo/undertaker/issues/48
     def make(headers):
         request_headers = {}
         user_agent = request.headers.get('User-Agent')


### PR DESCRIPTION
or else you could send events to saas instead of your self-hosted sentry. Don't bother changing the URL everytime, just pull the right value from the DSN as it's already there:

#### self-hosted
http://09aa0d909232457a8a6dfff118bac658@localhost:9000/2

#### hosted
https://81dff1d384484340ba71696c044ffe24@o87286.ingest.sentry.io/1316515

### Done
- Enforce Host in Store Endpoint matches the DSN's Host
- get event by its 'id' passed from command line (o)
- can run react/flask demo which sends 2 events at near-same time, and saves to sqlite

New in Q2 2020
https://develop.sentry.dev/sdk