### PR TITLE
AM Transactions - Javascript

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 proxy:
 	FLASK_APP=./python/proxy.py FLASK_ENV=development flask run -p 3001
 
+proxyhttps:
+	FLASK_APP=./python/proxy.py FLASK_ENV=development flask run --cert=adhoc -p 3001
+
 event:
 	go run event.go
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ https://develop.sentry.dev/sdk/event-payloads/ for what a sdk event looks like. 
 
 - AM transactions
 - Android errors/crashes/sessions
+pip install pyopenssl
 
 - sentry-cli for Release for js events from Database, so they're minified
 - sentry-cli should create a release and associate commits, use a Release# that relates to day of the week or day/month/year

--- a/deprecated/notes-python.txt
+++ b/deprecated/notes-python.txt
@@ -17,9 +17,6 @@ python2 BytesIO buffer getvalue() returns string instead of bytes (python3)
 
 
 
-
-
-
 request.data for javascript going into sqlite should be fine...
 request_headers = {}
 for key in ['Host','Accept-Encoding','Content-Length','Content-Encoding','Content-Type','User-Agent']:
@@ -27,3 +24,75 @@ for key in ['Host','Accept-Encoding','Content-Length','Content-Encoding','Conten
 
 
 return "http://sentry.io/api/%s/store/?sentry_key=%s&sentry_version=7" % (PROJECT_ID, KEY)
+
+
+
+
+05/31/2020
+HOW TO PRETTY PRINT TYPES OF HEADERS AND REQUEST BODY
+    print('> type(request.data)', type(request.data))
+    print('> type(request_headers)', type(request.headers))
+
+HOW TO PRETTY PRINT FLASK CLASS HEADERS
+    for header in request.headers.to_wsgi_list():
+        print(header)
+
+
+HOW TO PRETTY PRINT FLASK CLASS REQUEST BODY
+    json.dumps(json.loads(decompress_gzip(request.data)),indent=2))
+    json.dumps(json.loads(request.data),indent=2)
+
+
+
+05/31/2020
+HEADERS for Error and Transaction look same
+
+for header in request.headers.to_wsgi_list:
+  print(header)
+
+  Welcome To The
+_   _   _   _   ____    _____   ____    _____      _      _  __  _____   ____  
+| | | | | \ | | |  _ \  | ____| |  _ \  |_   _|    / \    | |/ / | ____| |  _ \ 
+| | | | |  \| | | | | | |  _|   | |_) |   | |     / _ \   | ' /  |  _|   | |_) |
+| |_| | | |\  | | |_| | | |___  |  _ <    | |    / ___ \  | . \  | |___  |  _ < 
+\___/  |_| \_| |____/  |_____| |_| \_\   |_|   /_/   \_\ |_|\_\ |_____| |_| \_                                                                                 
+
+('> database', '/home/wcap/thinkocapo/undertaker/sqlite.db')
+* Debugger is active!
+* Debugger PIN: 285-013-855
+> SAVING
+('> type(request.data)', <type 'str'>)
+('> type(request.headers)', <class 'werkzeug.datastructures.EnvironHeaders'>)
+('Referer', 'http://localhost:5000/')
+('Origin', 'http://localhost:5000')
+('Content-Length', '6868')
+('User-Agent', 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.122 Safari/537.36')
+('Connection', 'keep-alive')
+('Sec-Fetch-Dest', 'empty')
+('Sec-Fetch-Mode', 'cors')
+('Host', 'localhost:3001')
+('Sec-Fetch-Site', 'same-site')
+('Accept', '*/*')
+('Accept-Language', 'en-US,en;q=0.9,uk-UA;q=0.8,uk;q=0.7,es-US;q=0.6,es;q=0.5,ru-RU;q=0.4,ru;q=0.3,pt-BR;q=0.2,pt;q=0.1')
+('Content-Type', 'text/plain;charset=UTF-8')
+('Accept-Encoding', 'gzip, deflate, br')
+> javascript error type
+127.0.0.1 - - [31/May/2020 10:21:50] "POST /api/3/store/?sentry_key=0d52d5f4e8a64f5ab2edce50d88a7626&sentry_version=7 HTTP/1.1" 200 -
+> SAVING
+('> type(request.data)', <type 'str'>)
+('> type(request.headers)', <class 'werkzeug.datastructures.EnvironHeaders'>)
+('Referer', 'http://localhost:5000/')
+('Origin', 'http://localhost:5000')
+('Content-Length', '5236')
+('User-Agent', 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.122 Safari/537.36')
+('Connection', 'keep-alive')
+('Sec-Fetch-Dest', 'empty')
+('Sec-Fetch-Mode', 'cors')
+('Host', 'localhost:3001')
+('Sec-Fetch-Site', 'same-site')
+('Accept', '*/*')
+('Accept-Language', 'en-US,en;q=0.9,uk-UA;q=0.8,uk;q=0.7,es-US;q=0.6,es;q=0.5,ru-RU;q=0.4,ru;q=0.3,pt-BR;q=0.2,pt;q=0.1')
+('Content-Type', 'text/plain;charset=UTF-8')
+('Accept-Encoding', 'gzip, deflate, br')
+> javascript error type
+127.0.0.1 - - [31/May/2020 10:22:08] "POST /api/3/store/?sentry_key=0d52d5f4e8a64f5ab2edce50d88a7626&sentry_version=7 HTTP/1.1" 200 -

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -151,8 +151,9 @@ func javascript(bodyBytes []byte, headers []byte) {
 	responseData, responseDataErr := ioutil.ReadAll(response.Body)
 	if responseDataErr != nil { log.Fatal(responseDataErr) }
 
-	fmt.Printf("\n> javascript event response\n", responseData)
-	// fmt.Printf("\n> javascript event response", string(responseData))
+	// TODO this prints nicely if response is coming from Self-Hosted. Not the case when sending to Hosted sentry
+	fmt.Printf("\n> javascript event response", string(responseData))
+	// fmt.Printf("\n> javascript event response\n", responseData)
 }
 
 func python(bodyBytesCompressed []byte, headers []byte) {

--- a/python/event.py
+++ b/python/event.py
@@ -43,7 +43,7 @@ def app():
     # stacktrace()
     
     # Exception literals will not have stack traces
-    sentry_sdk.capture_exception(Exception("good456"))
+    sentry_sdk.capture_exception(Exception("steel449"))
 
 def dsn_and_proxy_check():
     if DSN=='':
@@ -59,7 +59,7 @@ def dsn_and_proxy_check():
         s.close()
     
 def initialize_sentry():
-    params = { 'dsn': MODIFIED_DSN_SAVE }
+    params = { 'dsn': MODIFIED_DSN_FORWARD }
     sentry_sdk.init(params)
     
 if __name__ == '__main__':

--- a/python/proxy.py
+++ b/python/proxy.py
@@ -28,6 +28,8 @@ print("""
                                                                                  
 """)
 
+
+
 SENTRY=''
 
 # Must pass auth key in URL (not request headers) or else 403 CSRF error from Sentry
@@ -76,34 +78,28 @@ with sqlite3.connect(database) as db:
 def forward():
     print('> FORWARD')
 
-    # print('> type(request.data)', type(request.data))
-    # print('> type(request_headers)', type(request.headers))
-
-    # print('\n111 REQUEST headers\n', request.headers)
-    # print('\n111 REQUEST body\n', json.dumps(json.loads(decompress_gzip(request.data)),indent=2))
-
     # TODO https://github.com/thinkocapo/undertaker/issues/48
     def make(headers):
         request_headers = {}
-        user_agent = request.headers.get('User-Agent')
-        if 'ython' in user_agent:
-            print('> python error')
+        user_agent = request.headers.get('User-Agent').lower()
+        if 'python' in user_agent:
+            print('> Python error')
             for key in ['Accept-Encoding','Content-Length','Content-Encoding','Content-Type','User-Agent']:
                 request_headers[key] = request.headers.get(key)
                 # TODO Original, 'flask' project
-                SENTRY = sentryUrl(os.getenv('DSN_PYTHON'))
+                # SENTRY = sentryUrl(os.getenv('DSN_PYTHON'))
                 # SENTRY = sentryUrl(os.getenv('DSN_PYTHON_SAAS'))
-                # SENTRY = sentryUrl(os.getenv('DSN_PYTHONEAT_SAAS'))
-        if 'ozilla' in user_agent or 'hrome' in user_agent or 'afari' in user_agent:
-            print('> javascript error')
+                SENTRY = sentryUrl(os.getenv('DSN_PYTHONEAT_SAAS'))
+        if 'mozilla' in user_agent or 'chrome' in user_agent or 'safari' in user_agent:
+            print('> Javascript error')
             for key in ['Accept-Encoding','Content-Length','Content-Type','User-Agent']:
                 request_headers[key] = request.headers.get(key)
-                SENTRY = sentryUrl(os.getenv('DSN_REACT'))
-                # SENTRY = sentryUrl(os.getenv('DSN_REACT_SAAS'))
+                # SENTRY = sentryUrl(os.getenv('DSN_REACT'))
+                SENTRY = sentryUrl(os.getenv('DSN_REACT_SAAS'))
         return request_headers, SENTRY
 
     request_headers, SENTRY = make(request.headers)
-    print('> SENTRY url is', SENTRY)
+    print('> SENTRY url for store endpoint', SENTRY)
 
     try:
         print('> type(request.data)', type(request.data))

--- a/python/proxy.py
+++ b/python/proxy.py
@@ -15,6 +15,7 @@ load_dotenv()
 http = urllib3.PoolManager()
 
 app = Flask(__name__)
+# app.run(ssl_context='adhoc') # flask run --cert=adhoc
 CORS(app)
 
 print("""
@@ -61,13 +62,13 @@ with sqlite3.connect(database) as db:
 # MODIFIED_DSN_FORWARD - Intercepts the payload sent by sentry_sdk in event.py, and then sends it to a Sentry instance
 @app.route('/api/2/store/', methods=['POST'])
 def forward():
-    print('> FORWARD')
+    print('> 0000000000 FORWARD')
 
-    print('\n111 REQUEST headers\n', request.headers)
+    # print('> type(request.data)', type(request.data))
+    # print('> type(request_headers)', type(request.headers))
 
-    print('\n111 REQUEST body\n', json.dumps(json.loads(decompress_gzip(request.data)),indent=2))
-
-
+    # print('\n111 REQUEST headers\n', request.headers)
+    # print('\n111 REQUEST body\n', json.dumps(json.loads(decompress_gzip(request.data)),indent=2))
 
     # TODO https://github.com/thinkocapo/undertaker/issues/48
     def make(headers):
@@ -77,29 +78,35 @@ def forward():
             print('> python error')
             for key in ['Accept-Encoding','Content-Length','Content-Encoding','Content-Type','User-Agent']:
                 request_headers[key] = request.headers.get(key)
+                # TODO Original, 'flask' project
                 SENTRY = sentryUrl(os.getenv('DSN_PYTHON'))
+                # SENTRY = sentryUrl(os.getenv('DSN_PYTHON_SAAS'))
+                # SENTRY = sentryUrl(os.getenv('DSN_PYTHONEAT_SAAS'))
         if 'ozilla' in user_agent or 'hrome' in user_agent or 'afari' in user_agent:
             print('> javascript error')
             for key in ['Accept-Encoding','Content-Length','Content-Type','User-Agent']:
                 request_headers[key] = request.headers.get(key)
                 SENTRY = sentryUrl(os.getenv('DSN_REACT'))
+                # SENTRY = sentryUrl(os.getenv('DSN_REACT_SAAS'))
         return request_headers, SENTRY
 
-    request_headers, SENTRY = make(request.headers) # could make return 2 values? https://note.nkmk.me/en/python-function-return-multiple-values/
+    request_headers, SENTRY = make(request.headers)
     print('> SENTRY url is', SENTRY)
-    
+    # return 'END EXPERIMENT'
+
     try:
         print('> type(request.data)', type(request.data))
         print('> type(request_headers)', type(request_headers))
 
-        response = http.request(
-            "POST", str(SENTRY), body=request.data, headers=request_headers 
-        )
+        # response = http.request(
+        #     "POST", str(SENTRY), body=request.data, headers=request_headers 
+        # )
 
         print('> nothing saved to sqlite database')
         return 'success'
     except Exception as err:
-        print('LOCAL EXCEPTION', err)
+        # print('LOCAL EXCEPTION', err)
+        print('DONE')
 
 # MODIFIED_DSN_SAVE - Intercepts event from sentry sdk and saves them to Sqlite DB. No forward of event to your Sentry instance.
 @app.route('/api/3/store/', methods=['POST'])

--- a/python/proxy.py
+++ b/python/proxy.py
@@ -63,6 +63,12 @@ with sqlite3.connect(database) as db:
 def forward():
     print('> FORWARD')
 
+    print('\n111 REQUEST headers\n', request.headers)
+
+    print('\n111 REQUEST body\n', json.dumps(json.loads(decompress_gzip(request.data)),indent=2))
+
+
+
     # TODO https://github.com/thinkocapo/undertaker/issues/48
     def make(headers):
         request_headers = {}

--- a/python/proxy.py
+++ b/python/proxy.py
@@ -109,15 +109,14 @@ def forward():
         print('> type(request.data)', type(request.data))
         print('> type(request_headers)', type(request_headers))
 
-        # response = http.request(
-        #     "POST", str(SENTRY), body=request.data, headers=request_headers 
-        # )
+        response = http.request(
+            "POST", str(SENTRY), body=request.data, headers=request_headers 
+        )
 
         print('> nothing saved to sqlite database')
         return 'success'
     except Exception as err:
-        # print('LOCAL EXCEPTION', err)
-        print('DONE')
+        print('LOCAL EXCEPTION', err)
 
 # MODIFIED_DSN_SAVE - Intercepts event from sentry sdk and saves them to Sqlite DB. No forward of event to your Sentry instance.
 @app.route('/api/3/store/', methods=['POST'])


### PR DESCRIPTION
## Prep
To prepare for this, the sdk's in thinkocapo/react thinkocapo/flask had to be updated so they can send Transactions to the proxy
- updated to js sentry sdk 5.15.5
```
  <script src="https://browser.sentry-cdn.com/5.15.5/bundle.min.js" crossorigin="anonymous"></script>
  <script src="https://browser.sentry-cdn.com/5.15.5/bundle.apm.min.js" crossorigin="anonymous"></script>
```
- updated to python sentry sdk 5.15.5

First ^ tested these by sending directly to Sentry.io, then routed them through the proxy:

## Note
github.com/getsentry/onpremise is v10.0.0 which does not support AM Transactions (currently in beta) as of today 05/30/2020, and so this will be tested against the Hosted version of Sentry. But that's where we want the test data anyways.

If you're going through the "Forward" endpoints in the proxy, then it makes a big difference as to what your starting DSN key was (see below).

But if you're doing Save and then using Go to send the events, it doesn't make a difference if your dsn was from a self-hosted or provided by hosted Sentry.

"Forward" is good for inspecting the headers for now, and testing that the Transactions are actually accepted from thinkocapo/react thinkocapo/flask. It also helped discover the http vs https dilemma.

## Done
- tested that Proxy can receive Transactions and Errors from a DSN (saas) like `https://0d52d5f4e8a64f5ab2edce50d88a7626@o87286.ingest.sentry.io/1428657` but must remove the 's' from 'https' so it's http, or else Flask will reject the https request from front-end
- tested that Proxy can then forward these Transactions and Errors onwards to SaaS

- updated SentryUrl() function so that HOST is now dynamically generated based on if DSN came from self-hosted (localhost:9000 is in the DSN's rawurl form) versus from SaaS (ingest.sentry.io is in the DSN's rawurl form)
- updated storeEndpoint (Go) function so that http vs https is set based on the HOST property.


This is supposed to allow Flask to accept from https? opened https://github.com/thinkocapo/undertaker/issues/51
```
flask run --cert=adhoc
```
or this:
```
app = Flask(__name__)
app.run(ssl_context='adhoc') # flask run --cert=adhoc
CORS(app)
```

## Also
opened https://github.com/thinkocapo/undertaker/issues/52 for:
    print('> type(request.data)', type(request.data))
    print('> type(request_headers)', type(request.headers))

HOW TO PRETTY PRINT FLASK CLASS HEADERS
    for header in request.headers.to_wsgi_list():
        print(header)


HOW TO PRETTY PRINT FLASK CLASS REQUEST BODY
    json.dumps(json.loads(decompress_gzip(request.data)),indent=2))
    json.dumps(json.loads(request.data),indent=2)

