### PR TITLE
Transactions in Javascript - Update timestamps

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -14,67 +14,51 @@ func main() {
 	// if err != nil {
 	// 	panic(err)
 	// }
-
 	// quantity := decimal.NewFromInt(3)
-
 	// fee, _ := decimal.NewFromString(".035")
 	// taxRate, _ := decimal.NewFromString(".08875")
-
 	// subtotal := price.Mul(quantity)
-
 	// preTax := subtotal.Mul(fee.Add(decimal.NewFromFloat(1)))
-
 	// total := preTax.Mul(taxRate.Add(decimal.NewFromFloat(1)))
-
 	// fmt.Println("Subtotal:", subtotal)                      // Subtotal: 408.06
 	// fmt.Println("Pre-tax:", preTax)                         // Pre-tax: 422.3421
 	// fmt.Println("Taxes:", total.Sub(preTax))                // Taxes: 37.482861375
 	// fmt.Println("Total:", total)                            // Total: 459.824961375
 	// fmt.Println("Tax rate:", total.Sub(preTax).Div(preTax)) // Tax rate: 0.08875
-
+	
 	// TODO try with 1591051102.7653 as well
-	
-	// ?
-	// timestamp, _ := decimal.NewFromString(string(time.Now().Unix()))
-	// timestamp := decimal.NewFromFloat(float64(time.Now().Unix()))
-	
 	parentStartTimestamp, _ := decimal.NewFromString("1591051102.765368")
 	parentEndTimestamp, _ := decimal.NewFromString("1591051102.777408")
 	fmt.Printf("\njs    parentStartTimestamp %v (%T)\n", parentStartTimestamp, parentStartTimestamp)
 
-
 	parentDifference := parentEndTimestamp.Sub(parentStartTimestamp)
-	fmt.Printf("\nparentDifference %v (%T)\n", parentDifference, parentDifference)
+	fmt.Printf("\njs        parentDifference %v (%T)\n", parentDifference, parentDifference)
 
 	newParentStartTime := time.Now().UnixNano()
 	newParentStartTimestamp := fmt.Sprint(newParentStartTime)
 	newParentStartTimestamp = newParentStartTimestamp[:10] + "." + newParentStartTimestamp[10:]
 	fmt.Printf("\njs newParentStartTimestamp %v (%T)\n", newParentStartTimestamp, newParentStartTimestamp)
 
-	// newParentEndTimestamp := newParentStartTimestamp + parentDifference
+	newParentStartTimestampDecimal, _ := decimal.NewFromString(newParentStartTimestamp)
+	newParentEndTimestamp := newParentStartTimestampDecimal.Add(parentDifference)
+	fmt.Printf("\njs newParentEndTimestamp %v (%T)\n", newParentEndTimestamp, newParentEndTimestamp)
 
-	// WORKS 06/05/2020 10:13p	
-	// sentryTimestamp := newStartTimestamp[:11] + "." + newStartTimestamp[11:]
-	// fmt.Println("\nsentryTimestamp:", sentryTimestamp)
-	
-	
-	
-	// ?
+
+	// RUn this Test
+	// (newParentEndTimestamp - newParentStartTimestamp) == parentDifference
+
+	// timestamp, _ := decimal.NewFromString(string(time.Now().Unix()))
+	// timestamp := decimal.NewFromFloat(float64(time.Now().Unix()))
+
 	// timestamp = strconv.FormatInt(timestamp, 10)
 
-	//?
 	// timestamp1000 := time.Now().UnixNano()
 	// base := timestamp1000 / 1000000
 	// modulo := timestamp % 1000000
 	// fmt.Println("\ntimestamp1000 base:", base)
 	// fmt.Println("\ntimestamp1000 modulo:", modulo)
 
-
-
-
-
-
-
+		//
 	// myv := float64(ts) // fails
 
 	// newStartTimestamp := timestamp

--- a/decimal.go
+++ b/decimal.go
@@ -46,8 +46,16 @@ func main() {
 	// fmt.Println("\ntstring:", timestamp)
 
 	ts := timestamp1[:10] + "." + timestamp1[11:]
-
+	// https://github.com/getsentry/sentry-javascript/tree/master/packages/utils
+	// https://github.com/getsentry/sentry-javascript/blob/c6a2ec95f5c21df5fb6c4d7ee07087b615e23436/packages/utils/src/misc.ts
 	fmt.Println("\ntimestamp:", ts)
+
+	timestamp1000 := time.Now().UnixNano()
+	base := timestamp1000 / 1000000
+	modulo := timestamp % 1000000
+	fmt.Println("\ntimestamp1000 base:", base)
+	fmt.Println("\ntimestamp1000 modulo:", modulo)
+
 
 	// myv := float64(ts) // fails
 

--- a/decimal.go
+++ b/decimal.go
@@ -7,6 +7,8 @@ import (
 	"time"
 )
 
+// https://github.com/getsentry/sentry-javascript/tree/master/packages/utils
+// https://github.com/getsentry/sentry-javascript/blob/c6a2ec95f5c21df5fb6c4d7ee07087b615e23436/packages/utils/src/misc.ts
 func main() {
 	// price, err := decimal.NewFromString("136.02")
 	// if err != nil {
@@ -30,6 +32,7 @@ func main() {
 	// fmt.Println("Total:", total)                            // Total: 459.824961375
 	// fmt.Println("Tax rate:", total.Sub(preTax).Div(preTax)) // Tax rate: 0.08875
 
+	// try with 1591051102.7653 as well
 	startTimestamp, _ := decimal.NewFromString("1591051102.765368")
 	endTimestamp, _ := decimal.NewFromString("1591051102.777408")
 
@@ -39,16 +42,14 @@ func main() {
 	// timestamp, _ := decimal.NewFromString(string(time.Now().Unix()))
 	// timestamp := decimal.NewFromFloat(float64(time.Now().Unix()))
 	timestamp := time.Now().UnixNano()
-
 	timestamp1 := fmt.Sprint(timestamp)
 
 	// timestamp = strconv.FormatInt(timestamp, 10)
 	// fmt.Println("\ntstring:", timestamp)
 
-	ts := timestamp1[:10] + "." + timestamp1[11:]
-	// https://github.com/getsentry/sentry-javascript/tree/master/packages/utils
-	// https://github.com/getsentry/sentry-javascript/blob/c6a2ec95f5c21df5fb6c4d7ee07087b615e23436/packages/utils/src/misc.ts
-	fmt.Println("\ntimestamp:", ts)
+	fmt.Println("\ntimestamp timestamp1:", timestamp1)
+	sentryTimestamp := timestamp1[:11] + "." + timestamp1[11:]
+	fmt.Println("\ntimestamp         sentryTimestamp:", sentryTimestamp)
 
 	timestamp1000 := time.Now().UnixNano()
 	base := timestamp1000 / 1000000
@@ -56,14 +57,12 @@ func main() {
 	fmt.Println("\ntimestamp1000 base:", base)
 	fmt.Println("\ntimestamp1000 modulo:", modulo)
 
-
 	// myv := float64(ts) // fails
 
 	// newStartTimestamp := timestamp
 	// newEndTimestamp := timestamp.Add(difference)
 	// fmt.Println("\nnewStartTimestamp:", newStartTimestamp)
 	// fmt.Println("\nnewEndTimestamp:", newEndTimestamp)
-
 
 	// now1 := time.Now()
 	// fmt.Print("time.Now().UnixNano()", now1.UnixNano())

--- a/decimal.go
+++ b/decimal.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"fmt"
+	"github.com/shopspring/decimal"
+	// "strconv"
+	"time"
+)
+
+func main() {
+	// price, err := decimal.NewFromString("136.02")
+	// if err != nil {
+	// 	panic(err)
+	// }
+
+	// quantity := decimal.NewFromInt(3)
+
+	// fee, _ := decimal.NewFromString(".035")
+	// taxRate, _ := decimal.NewFromString(".08875")
+
+	// subtotal := price.Mul(quantity)
+
+	// preTax := subtotal.Mul(fee.Add(decimal.NewFromFloat(1)))
+
+	// total := preTax.Mul(taxRate.Add(decimal.NewFromFloat(1)))
+
+	// fmt.Println("Subtotal:", subtotal)                      // Subtotal: 408.06
+	// fmt.Println("Pre-tax:", preTax)                         // Pre-tax: 422.3421
+	// fmt.Println("Taxes:", total.Sub(preTax))                // Taxes: 37.482861375
+	// fmt.Println("Total:", total)                            // Total: 459.824961375
+	// fmt.Println("Tax rate:", total.Sub(preTax).Div(preTax)) // Tax rate: 0.08875
+
+	startTimestamp, _ := decimal.NewFromString("1591051102.765368")
+	endTimestamp, _ := decimal.NewFromString("1591051102.777408")
+
+	difference := endTimestamp.Sub(startTimestamp)
+	fmt.Println("\nDifference:", difference)
+
+	// timestamp, _ := decimal.NewFromString(string(time.Now().Unix()))
+	// timestamp := decimal.NewFromFloat(float64(time.Now().Unix()))
+	timestamp := time.Now().UnixNano()
+
+	timestamp1 := fmt.Sprint(timestamp)
+
+	// timestamp = strconv.FormatInt(timestamp, 10)
+	// fmt.Println("\ntstring:", timestamp)
+
+	ts := timestamp1[:10] + "." + timestamp1[11:]
+
+	fmt.Println("\ntimestamp:", ts)
+
+	// myv := float64(ts) // fails
+
+	// newStartTimestamp := timestamp
+	// newEndTimestamp := timestamp.Add(difference)
+	// fmt.Println("\nnewStartTimestamp:", newStartTimestamp)
+	// fmt.Println("\nnewEndTimestamp:", newEndTimestamp)
+
+
+	// now1 := time.Now()
+	// fmt.Print("time.Now().UnixNano()", now1.UnixNano())
+
+	// nanos := now1.UnixNano()
+	// logs "1591069805238407460" so could add decimal to that?
+	// fmt.Println("\nnanos", nanos)
+	// fmt.Println("\n", time.Unix(0, nanos))
+	return
+}

--- a/decimal.go
+++ b/decimal.go
@@ -45,25 +45,31 @@ func main() {
 	newParentEndTimestamp := newParentStartTimestampDecimal.Add(parentDifference)
 	fmt.Printf("\njs newParentEndTimestamp %v (%T)\n", newParentEndTimestamp, newParentEndTimestamp)
 
-	// TODO
-	// 1.
-	func updateSpan(parentStartTimestamp) {
-		spanStartTimestamp, _ := decimal.NewFromString(span.start_timestamp)
-		spanStartTimestamp, _ := decimal.NewFromString(span.timestamp)
-		// ^ format it with right decimals so can do subtraction:
-
-		spanStartDifference := spanStartTimestamp.Sub(parentStartTimestamp)
-		spanEndDifference := spanEndTimestamp.Sub(parentStartTimestamp)
-
-		newSpanStartTimestamp := newParentStartTimestamp.Add(spanStartDifference)
-		newSpanEndTimestamp := newParentStartTimestamp.Add(spanEndDifference)
-
+	if (newParentEndTimestamp.Sub(newParentStartTimestampDecimal).Equal(parentDifference)) {
+		fmt.Printf("\nTRUE")
+	} else {
+		fmt.Printf("\nFALSE - not equal")
+		fmt.Print(newParentEndTimestamp.Sub(newParentStartTimestampDecimal))
 	}
 
+	// TODO
+	// 1.
+	// func updateSpan(parentStartTimestamp) {
+	// 	spanStartTimestamp, _ := decimal.NewFromString(span.start_timestamp)
+	// 	spanStartTimestamp, _ := decimal.NewFromString(span.timestamp)
+	// 	// ^ format it with right decimals so can do subtraction:
 
-	// RUn this Test
-	// (newParentEndTimestamp - newParentStartTimestamp) == parentDifference
+	// 	spanStartDifference := spanStartTimestamp.Sub(parentStartTimestamp)
+	// 	spanEndDifference := spanEndTimestamp.Sub(parentStartTimestamp)
 
+	// 	newSpanStartTimestamp := newParentStartTimestamp.Add(spanStartDifference)
+	// 	newSpanEndTimestamp := newParentStartTimestamp.Add(spanEndDifference)
+	// }
+
+
+
+
+	/////////////////////////////////////////////////////////////////////////////
 	// timestamp, _ := decimal.NewFromString(string(time.Now().Unix()))
 	// timestamp := decimal.NewFromFloat(float64(time.Now().Unix()))
 

--- a/decimal.go
+++ b/decimal.go
@@ -32,30 +32,48 @@ func main() {
 	// fmt.Println("Total:", total)                            // Total: 459.824961375
 	// fmt.Println("Tax rate:", total.Sub(preTax).Div(preTax)) // Tax rate: 0.08875
 
-	// try with 1591051102.7653 as well
-	startTimestamp, _ := decimal.NewFromString("1591051102.765368")
-	endTimestamp, _ := decimal.NewFromString("1591051102.777408")
-
-	difference := endTimestamp.Sub(startTimestamp)
-	fmt.Println("\nDifference:", difference)
-
+	// TODO try with 1591051102.7653 as well
+	
+	// ?
 	// timestamp, _ := decimal.NewFromString(string(time.Now().Unix()))
 	// timestamp := decimal.NewFromFloat(float64(time.Now().Unix()))
-	timestamp := time.Now().UnixNano()
-	timestamp1 := fmt.Sprint(timestamp)
+	
+	parentStartTimestamp, _ := decimal.NewFromString("1591051102.765368")
+	parentEndTimestamp, _ := decimal.NewFromString("1591051102.777408")
+	fmt.Printf("\njs    parentStartTimestamp %v (%T)\n", parentStartTimestamp, parentStartTimestamp)
 
+
+	parentDifference := parentEndTimestamp.Sub(parentStartTimestamp)
+	fmt.Printf("\nparentDifference %v (%T)\n", parentDifference, parentDifference)
+
+	newParentStartTime := time.Now().UnixNano()
+	newParentStartTimestamp := fmt.Sprint(newParentStartTime)
+	newParentStartTimestamp = newParentStartTimestamp[:10] + "." + newParentStartTimestamp[10:]
+	fmt.Printf("\njs newParentStartTimestamp %v (%T)\n", newParentStartTimestamp, newParentStartTimestamp)
+
+	// newParentEndTimestamp := newParentStartTimestamp + parentDifference
+
+	// WORKS 06/05/2020 10:13p	
+	// sentryTimestamp := newStartTimestamp[:11] + "." + newStartTimestamp[11:]
+	// fmt.Println("\nsentryTimestamp:", sentryTimestamp)
+	
+	
+	
+	// ?
 	// timestamp = strconv.FormatInt(timestamp, 10)
-	// fmt.Println("\ntstring:", timestamp)
 
-	fmt.Println("\ntimestamp timestamp1:", timestamp1)
-	sentryTimestamp := timestamp1[:11] + "." + timestamp1[11:]
-	fmt.Println("\ntimestamp         sentryTimestamp:", sentryTimestamp)
+	//?
+	// timestamp1000 := time.Now().UnixNano()
+	// base := timestamp1000 / 1000000
+	// modulo := timestamp % 1000000
+	// fmt.Println("\ntimestamp1000 base:", base)
+	// fmt.Println("\ntimestamp1000 modulo:", modulo)
 
-	timestamp1000 := time.Now().UnixNano()
-	base := timestamp1000 / 1000000
-	modulo := timestamp % 1000000
-	fmt.Println("\ntimestamp1000 base:", base)
-	fmt.Println("\ntimestamp1000 modulo:", modulo)
+
+
+
+
+
 
 	// myv := float64(ts) // fails
 

--- a/decimal.go
+++ b/decimal.go
@@ -27,6 +27,8 @@ func main() {
 	// fmt.Println("Tax rate:", total.Sub(preTax).Div(preTax)) // Tax rate: 0.08875
 	
 	// TODO try with 1591051102.7653 as well
+
+	// TODO - needs to be the real event.trace.context.spanid/start_timestamp AND formatted with proper decimal...
 	parentStartTimestamp, _ := decimal.NewFromString("1591051102.765368")
 	parentEndTimestamp, _ := decimal.NewFromString("1591051102.777408")
 	fmt.Printf("\njs    parentStartTimestamp %v (%T)\n", parentStartTimestamp, parentStartTimestamp)
@@ -42,6 +44,21 @@ func main() {
 	newParentStartTimestampDecimal, _ := decimal.NewFromString(newParentStartTimestamp)
 	newParentEndTimestamp := newParentStartTimestampDecimal.Add(parentDifference)
 	fmt.Printf("\njs newParentEndTimestamp %v (%T)\n", newParentEndTimestamp, newParentEndTimestamp)
+
+	// TODO
+	// 1.
+	func updateSpan(parentStartTimestamp) {
+		spanStartTimestamp, _ := decimal.NewFromString(span.start_timestamp)
+		spanStartTimestamp, _ := decimal.NewFromString(span.timestamp)
+		// ^ format it with right decimals so can do subtraction:
+
+		spanStartDifference := spanStartTimestamp.Sub(parentStartTimestamp)
+		spanEndDifference := spanEndTimestamp.Sub(parentStartTimestamp)
+
+		newSpanStartTimestamp := newParentStartTimestamp.Add(spanStartDifference)
+		newSpanEndTimestamp := newParentStartTimestamp.Add(spanEndDifference)
+
+	}
 
 
 	// RUn this Test

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	// "strconv"
 	"strings"
 	"time"
 )
@@ -127,6 +128,7 @@ func javascript(event Event) {
 		bodyInterface = updateTimestamp(bodyInterface, "javascript")
 	}
 	if (event._type == "transaction") {
+		fmt.Println(bodyInterface["start_timestamp"])
 		bodyInterface = updateTimestamps(bodyInterface, "javascript")
 	}
 
@@ -144,14 +146,14 @@ func javascript(event Event) {
 		request.Header.Set(v, headerInterface[v].(string))
 	}
 	
-	response, requestErr := httpClient.Do(request)
-	if requestErr != nil { fmt.Println(requestErr) }
+	// response, requestErr := httpClient.Do(request)
+	// if requestErr != nil { fmt.Println(requestErr) }
 
-	responseData, responseDataErr := ioutil.ReadAll(response.Body)
-	if responseDataErr != nil { log.Fatal(responseDataErr) }
+	// responseData, responseDataErr := ioutil.ReadAll(response.Body)
+	// if responseDataErr != nil { log.Fatal(responseDataErr) }
 
-	// TODO this prints nicely if response is coming from Self-Hosted. Not the case when sending to Hosted sentry
-	fmt.Printf("\n> javascript event response", string(responseData))
+	// // TODO this prints nicely if response is coming from Self-Hosted. Not the case when sending to Hosted sentry
+	// fmt.Printf("\n> javascript event response", string(responseData))
 }
 
 func python(event Event) {
@@ -165,6 +167,7 @@ func python(event Event) {
 		bodyInterface = updateTimestamp(bodyInterface, "python")
 	}
 	if (event._type == "transaction") {
+		fmt.Println(bodyInterface)
 		bodyInterface = updateTimestamps(bodyInterface, "python")
 	}
 	
@@ -186,13 +189,13 @@ func python(event Event) {
 		request.Header.Set(v, headerInterface[v].(string))
 	}
 
-	response, requestErr := httpClient.Do(request)
-	if requestErr != nil { fmt.Println(requestErr) }
+	// response, requestErr := httpClient.Do(request)
+	// if requestErr != nil { fmt.Println(requestErr) }
 
-	responseData, responseDataErr := ioutil.ReadAll(response.Body)
-	if responseDataErr != nil { log.Fatal(responseDataErr) }
+	// responseData, responseDataErr := ioutil.ReadAll(response.Body)
+	// if responseDataErr != nil { log.Fatal(responseDataErr) }
 
-	fmt.Printf("\n> python event response: %v\n", string(responseData))
+	// fmt.Printf("\n> python event response: %v\n", string(responseData))
 }
 
 func main() {
@@ -307,22 +310,29 @@ func updateTimestamp(bodyInterface map[string]interface{}, platform string) map[
 	return bodyInterface
 }
 
-func updateTimestamps(bodyInterface map[string]interface{}, platform string) map[string]interface{} {
+func updateTimestamps(data map[string]interface{}, platform string) map[string]interface{} {
 	// 'start_timestamp' is only present in transactions
-	fmt.Println("       timestamp before",bodyInterface["start_timestamp"])
-	fmt.Println(" start_timestamp before",bodyInterface["start_timestamp"])
+	fmt.Println("       timestamp before",data["start_timestamp"])
+	fmt.Println(" start_timestamp before",data["start_timestamp"])
+	
+	// bodyInterface == event
 	// event.context.trace.span_id
-	// event.startTimestamp
-	// event.endTimestamp
+
+	
+	// TODO
+	// timestamp := time.Now().Unix()
+	// startTimestamp, _ := strconv.ParseInt(data["startTimestamp"].(string), 64)
+	// endTimestamp, _ := strconv.ParseInt(data["endTimestamp"].(string), 64)
+	// data["startTimestamp"] = timestamp
+	// data["endTimestamp"] = timestamp + (endTimestamp - startTimestamp)
 
 	// for span in event.entrices[0].data: 
 		// start_timestamp
 		// timestamp
 
-	fmt.Println("       timestamp after",bodyInterface["start_timestamp"])
-	fmt.Println(" start_timestamp after",bodyInterface["start_timestamp"])
-	
-	return bodyInterface
+	fmt.Println("       timestamp after",data["start_timestamp"])
+	fmt.Println(" start_timestamp after",data["start_timestamp"])
+	return data
 }
 
 // SDK's are supposed to set timestamps https://github.com/getsentry/sentry-javascript/issues/2573

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -339,9 +339,9 @@ func updateTimestamps(data map[string]interface{}, platform string) map[string]i
 		newParentEndTimestamp := newParentStartTimestamp.Add(parentDifference)
 	
 		if (newParentEndTimestamp.Sub(newParentStartTimestamp).Equal(parentDifference)) {
-			fmt.Printf("\nTRUE - equal")
+			fmt.Printf("\nTRUE - parent")
 		} else {
-			fmt.Printf("\nFALSE - not equal")
+			fmt.Printf("\nFALSE - parent")
 			fmt.Print(newParentEndTimestamp.Sub(newParentStartTimestamp))
 		}
 
@@ -349,22 +349,58 @@ func updateTimestamps(data map[string]interface{}, platform string) map[string]i
 		data["start_timestamp"] = newParentStartTimestamp
 		data["timestamp"] = newParentEndTimestamp
 
-		fmt.Printf("\n> js1 updatetimestamps paraent start_timestamp after %v (%T)\n", data["start_timestamp"], data["start_timestamp"])
-		fmt.Printf("\n> js1 updatetimestamps paraent       timestamp after %v (%T)\n", data["timestamp"], data["timestamp"])
+		fmt.Printf("\n> js updatetimestamps parent start_timestamp after %v (%T)\n", data["start_timestamp"], data["start_timestamp"])
+		fmt.Printf("\n> js updatetimestamps parent       timestamp after %v (%T)\n", data["timestamp"], data["timestamp"])
 
+		// TEST...
+		firstSpan := data["spans"].([]interface{})[0].(map[string]interface{})
+		// both print...
+		// fmt.Printf("\n> *****************", firstSpan["start_timestamp"])
+		// fmt.Printf("\n> *****************", firstSpan["start_timestamp"].(float64))
+		fmt.Printf("\n> ***************** before ", decimal.NewFromFloat(firstSpan["start_timestamp"].(float64)))
+		
+
+		// fSp := firstSpan
+		
 		// SPANS
+		// for _, span := range data["spans"].(map[string]float64) {
 		for _, span := range data["spans"].([]interface{}) {
-			fmt.Printf("\n span \n", span)
+			// give it a type
+			sp := span.(map[string]interface{})
+			
+			fmt.Printf("\n> js updatetimestamps SPAN start_timestamp before %v (%T)", decimal.NewFromFloat(sp["start_timestamp"].(float64)), decimal.NewFromFloat(sp["start_timestamp"].(float64)))
+			fmt.Printf("\n> js updatetimestamps SPAN       timestamp before %v (%T)\n", decimal.NewFromFloat(sp["timestamp"].(float64))	, decimal.NewFromFloat(sp["timestamp"].(float64)))
+
+			spanStartTimestamp := decimal.NewFromFloat(sp["start_timestamp"].(float64))
+			spanEndTimestamp := decimal.NewFromFloat(sp["timestamp"].(float64))		
+			spanDifference := spanEndTimestamp.Sub(spanStartTimestamp)
+		
+			unixTimestampString := fmt.Sprint(time.Now().UnixNano())
+			newSpanStartTimestamp, _ := decimal.NewFromString(unixTimestampString[:10] + "." + unixTimestampString[10:])
+			newSpanEndTimestamp := newSpanStartTimestamp.Add(spanDifference)
+		
+			if (newSpanEndTimestamp.Sub(newSpanStartTimestamp).Equal(spanDifference)) {
+				fmt.Printf("TRUE - span")
+			} else {
+				fmt.Printf("\nFALSE - span")
+				fmt.Print(newSpanEndTimestamp.Sub(newSpanStartTimestamp))
+			}
+
+			// is okay that this is an instance of the 'decimal' package and no longer Float64? 
+			sp["start_timestamp"] = newSpanStartTimestamp
+			sp["timestamp"] = newSpanEndTimestamp
+
+			fmt.Printf("\n> js updatetimestamps SPAN start_timestamp after %v (%T)", sp["start_timestamp"], sp["start_timestamp"])
+			fmt.Printf("\n> js updatetimestamps SPAN       timestamp after %v (%T)\n", sp["timestamp"], sp["timestamp"])
 		}
 
-		// for _, v := range [4]string{"Accept-Encoding","Content-Length","Content-Type","User-Agent"} {
-		// 	request.Header.Set(v, headerInterface[v].(string))
-		// }
+		fmt.Printf("\n> ***************** after ", firstSpan["start_timestamp"])
+		// SUCCESS - it updated by reference
+		// before - 1591467416.0387652
+		// after  - 1591476953.491206959
 
-		
 	} 
 	
-
 	// if (platform == "python") {
 
 	// }

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -126,13 +126,9 @@ func javascript(event Event) {
 	if (event._type == "error") {
 		bodyInterface = updateTimestamp(bodyInterface, "javascript")
 	}
-	// if (event._type == "transaction") {
-	// 	bodyInterface = updateTimestamps(bodyInterface)
-	// }
-
-	// move to updateTimestamp(s) functions...
-	// fmt.Printf("> timestamp %v\n", bodyInterface["timestamp"])
-	// fmt.Printf("> start_timestamp %v\n", bodyInterface["start_timestamp"])
+	if (event._type == "transaction") {
+		bodyInterface = updateTimestamps(bodyInterface, "javascript")
+	}
 
 	bodyBytesPost := marshalJSON(bodyInterface)
 	
@@ -168,9 +164,9 @@ func python(event Event) {
 	if (event._type == "error") {
 		bodyInterface = updateTimestamp(bodyInterface, "python")
 	}
-	// if (event._type == "transaction") {
-	// 	bodyInterface = updateTimestamps(bodyInterface)
-	// }
+	if (event._type == "transaction") {
+		bodyInterface = updateTimestamps(bodyInterface, "python")
+	}
 	
 	// fmt.Printf("> timestamp %v\n", bodyInterface["timestamp"])
 	
@@ -315,8 +311,13 @@ func updateTimestamps(bodyInterface map[string]interface{}, platform string) map
 	// 'start_timestamp' is only present in transactions
 	fmt.Println("       timestamp before",bodyInterface["start_timestamp"])
 	fmt.Println(" start_timestamp before",bodyInterface["start_timestamp"])
+	// event.context.trace.span_id
+	// event.startTimestamp
+	// event.endTimestamp
 
-	// TODO - recursively go through all nested spans and update their timestamps...
+	// for span in event.entrices[0].data: 
+		// start_timestamp
+		// timestamp
 
 	fmt.Println("       timestamp after",bodyInterface["start_timestamp"])
 	fmt.Println(" start_timestamp after",bodyInterface["start_timestamp"])

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -310,14 +310,16 @@ func updateTimestamp(bodyInterface map[string]interface{}, platform string) map[
 	return bodyInterface
 }
 
+
+// JS some are like 1591419091.4805 but others 1591419092.000035
+// PYTHON are like 2020-06-06T04:54:56.636664Z
 func updateTimestamps(data map[string]interface{}, platform string) map[string]interface{} {
-	// 'start_timestamp' is only present in transactions
+	// 'start_timestamp' is only present in transactions. 'timestamp' represents end of the span/parent
 	fmt.Println("       timestamp before",data["start_timestamp"])
 	fmt.Println(" start_timestamp before",data["start_timestamp"])
 	
 	// bodyInterface == event
 	// event.context.trace.span_id
-
 	
 	// TODO
 	// timestamp := time.Now().Unix()

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -131,7 +131,7 @@ func javascript(event Event) {
 		bodyInterface = updateTimestamp(bodyInterface, "javascript")
 	}
 	if (event._type == "transaction") {
-		fmt.Println(bodyInterface["start_timestamp"])
+		// fmt.Println(bodyInterface["start_timestamp"])
 		bodyInterface = updateTimestamps(bodyInterface, "javascript")
 	}
 
@@ -279,10 +279,10 @@ func replaceEventId(bodyInterface map[string]interface{}) map[string]interface{}
 		log.Print("no event_id on object from DB")
 	}
 
-	fmt.Println("> before",bodyInterface["event_id"])
+	// fmt.Println("> before",bodyInterface["event_id"])
 	var uuid4 = strings.ReplaceAll(uuid.New().String(), "-", "") 
 	bodyInterface["event_id"] = uuid4
-	fmt.Println("> after ",bodyInterface["event_id"])
+	fmt.Println("> event_id after \n",bodyInterface["event_id"])
 	return bodyInterface
 }
 
@@ -324,36 +324,35 @@ func updateTimestamp(bodyInterface map[string]interface{}, platform string) map[
 func updateTimestamps(data map[string]interface{}, platform string) map[string]interface{} {
 	// fmt.Println("updateTimestamps       timestamp before", string(data["timestamp"].(string)))
 	// fmt.Println("updateTimestamps start_timestamp before", string(data["start_timestamp"].(string)))
-
 	// float64
 	// fmt.Printf("updateTimestamps       timestamp before %T \n", data["timestamp"])
 	// fmt.Printf("updateTimestamps start_timestamp before %T \n", data["start_timestamp"])
 	
-	fmt.Printf("updateTimestamps       timestamp before %v \n", decimal.NewFromFloat(data["timestamp"].(float64)))
-	fmt.Printf("updateTimestamps start_timestamp before %v \n", decimal.NewFromFloat(data["start_timestamp"].(float64)))
-
+	
 	if (platform == "javascript") {
-		// parentStartTimestamp, _ := decimal.NewFromString("1591051102.765368")
-		// parentEndTimestamp, _ := decimal.NewFromString("1591051102.777408")
-		parentStartTimestamp, _ := decimal.NewFromString(data["start_timestamp"].(string)[:10] + "." + data["start_timestamp"].(string)[10:])
-		parentEndTimestamp, _ := decimal.NewFromString(data["timestamp"].(string))
+		// in sqlite it was float64, not a string. or rather, Go is making it a float64 upon reading from db? not sure
+		fmt.Printf("> js updateTimestamps parent start_timestamp before %v (%T) \n", decimal.NewFromFloat(data["start_timestamp"].(float64)), decimal.NewFromFloat(data["start_timestamp"].(float64)))
+		fmt.Printf("> js updateTimestamps parent       timestamp before %v (%T) \n", decimal.NewFromFloat(data["timestamp"].(float64)), decimal.NewFromFloat(data["timestamp"].(float64)))
+		
+		parentStartTimestamp := decimal.NewFromFloat(data["start_timestamp"].(float64))
+		parentEndTimestamp := decimal.NewFromFloat(data["timestamp"].(float64))
 
-		fmt.Printf("\njs    parentStartTimestamp %v (%T)\n", parentStartTimestamp, parentStartTimestamp)
+		// fmt.Printf("\njs updateTimestamps parentStartTimestamp %v (%T)\n", parentStartTimestamp, parentStartTimestamp)
 	
 		parentDifference := parentEndTimestamp.Sub(parentStartTimestamp)
-		fmt.Printf("\njs        parentDifference %v (%T)\n", parentDifference, parentDifference)
+		// fmt.Printf("\njs updateTimestamps parentDifference %v (%T)\n", parentDifference, parentDifference)
 	
 		newParentStartTime := time.Now().UnixNano()
 		newParentStartTimestamp := fmt.Sprint(newParentStartTime)
 		newParentStartTimestamp = newParentStartTimestamp[:10] + "." + newParentStartTimestamp[10:]
-		fmt.Printf("\njs newParentStartTimestamp %v (%T)\n", newParentStartTimestamp, newParentStartTimestamp)
+		fmt.Printf("\n> js updatetimestamps parent start_timestamp after %v (%T)\n", newParentStartTimestamp, newParentStartTimestamp)
 	
 		newParentStartTimestampDecimal, _ := decimal.NewFromString(newParentStartTimestamp)
 		newParentEndTimestamp := newParentStartTimestampDecimal.Add(parentDifference)
-		fmt.Printf("\njs newParentEndTimestamp %v (%T)\n", newParentEndTimestamp, newParentEndTimestamp)
+		fmt.Printf("> js updatetimestamps parent       timestamp after %v (%T)\n", newParentEndTimestamp, newParentEndTimestamp)
 	
 		if (newParentEndTimestamp.Sub(newParentStartTimestampDecimal).Equal(parentDifference)) {
-			fmt.Printf("\nTRUE")
+			fmt.Printf("\nTRUE - equal")
 		} else {
 			fmt.Printf("\nFALSE - not equal")
 			fmt.Print(newParentEndTimestamp.Sub(newParentStartTimestampDecimal))

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -336,13 +336,16 @@ func updateTimestamps(data map[string]interface{}, platform string) map[string]i
 			fmt.Printf("\n> js updatetimestamps SPAN start_timestamp before %v (%T)", decimal.NewFromFloat(sp["start_timestamp"].(float64)), decimal.NewFromFloat(sp["start_timestamp"].(float64)))
 			fmt.Printf("\n> js updatetimestamps SPAN       timestamp before %v (%T)\n", decimal.NewFromFloat(sp["timestamp"].(float64))	, decimal.NewFromFloat(sp["timestamp"].(float64)))
 
+			
 			spanStartTimestamp := decimal.NewFromFloat(sp["start_timestamp"].(float64))
 			spanEndTimestamp := decimal.NewFromFloat(sp["timestamp"].(float64))		
 			spanDifference := spanEndTimestamp.Sub(spanStartTimestamp)
+			
+			spanToParentDifference := spanStartTimestamp.Sub(parentStartTimestamp)
 		
 			unixTimestampString := fmt.Sprint(time.Now().UnixNano())
 			unixTimestampDecimal, _ := decimal.NewFromString(unixTimestampString[:10] + "." + unixTimestampString[10:])
-			newSpanStartTimestamp := unixTimestampDecimal.Add(spanDifference)
+			newSpanStartTimestamp := unixTimestampDecimal.Add(spanToParentDifference)
 			newSpanEndTimestamp := newSpanStartTimestamp.Add(spanDifference)
 		
 			if (newSpanEndTimestamp.Sub(newSpanStartTimestamp).Equal(spanDifference)) {

--- a/test/db.py
+++ b/test/db.py
@@ -61,7 +61,7 @@ try:
             'id': sqlite_id,
             'platform': event_name,
             'type': event_type,
-            # 'buffer': json.loads(buffer),
+            'buffer': json.loads(buffer),
             'headers': json.loads(headers)
         }
         print(json.dumps(output, indent=2))

--- a/test/db.py
+++ b/test/db.py
@@ -61,7 +61,7 @@ try:
             'id': sqlite_id,
             'platform': event_name,
             'type': event_type,
-            'buffer': json.loads(buffer),
+            # 'buffer': json.loads(buffer),
             'headers': json.loads(headers)
         }
         print(json.dumps(output, indent=2))

--- a/test/db.py
+++ b/test/db.py
@@ -61,7 +61,7 @@ try:
             'id': sqlite_id,
             'platform': event_name,
             'type': event_type,
-            'buffer': json.loads(buffer),
+            'buffer': json.loads(buffer), # TODO add flag for 'include body' in query
             'headers': json.loads(headers)
         }
         print(json.dumps(output, indent=2))

--- a/test/db.py
+++ b/test/db.py
@@ -2,6 +2,7 @@ from gzip import GzipFile
 import json
 from six import BytesIO
 import sqlite3
+import sys
 
 """This tests how many records are in your Sqlite database"""
 
@@ -26,7 +27,15 @@ conn = sqlite3.connect(path_to_database)
 try:
     with conn:
         cur = conn.cursor()
-        cur.execute("SELECT * FROM events")
+    
+        _id = sys.argv[1] if len(sys.argv) > 1 else None
+        if _id==None:
+            cur.execute("SELECT * FROM events ORDER BY id DESC LIMIT 1;")
+        else:
+            cur.execute("SELECT * FROM events WHERE id=?", [_id])
+
+
+        # cur.execute("SELECT * FROM events")
 
         rows = cur.fetchall()
         print('TOTAL ROWS: ', len(rows))
@@ -37,7 +46,7 @@ try:
         row = rows[-1]
         
         # row by selection
-        row = rows[0]
+        # row = rows[0]
 
         # <read-write buffer ptr 0x562a8e765e30, size 1522 at 0x562a8e765df0>
         # <type 'buffer'>
@@ -52,8 +61,8 @@ try:
             'id': sqlite_id,
             'platform': event_name,
             'type': event_type,
-            'buffer': buffer,
-            'headers': headers
+            'buffer': json.loads(buffer),
+            'headers': json.loads(headers)
         }
         print(json.dumps(output, indent=2))
     

--- a/test/db.py
+++ b/test/db.py
@@ -33,8 +33,11 @@ try:
         # print('Most recent sqlite id:', rows[len(rows)-1][0]) # is latest??
  
         # TODO - iterate through all rows and print
+        # most recently added row
         row = rows[-1]
-        # row = list(row)
+        
+        # row by selection
+        row = rows[0]
 
         # <read-write buffer ptr 0x562a8e765e30, size 1522 at 0x562a8e765df0>
         # <type 'buffer'>
@@ -49,6 +52,7 @@ try:
             'id': sqlite_id,
             'platform': event_name,
             'type': event_type,
+            'buffer': buffer,
             'headers': headers
         }
         print(json.dumps(output, indent=2))


### PR DESCRIPTION
## Summary
Works for Javascript Transactions. python transactions have a different timestamp format, so do that in next PR.

## Done
- github.com/shopspring/decimal for decimals in Go
- updateTimestamp (error) vs updateTimestamps (transactions) in use
- `updateTimestamps()` algorithm/logic does the **Parent** aka **Trace** as well as their **spans**. The "new" start of a Span is relative to the start of trace, the "new" end is always relative to the difference from its "old" start. Hard to explain, see code and draw it out on paper, it's easier.
- the 'javascript' and 'python' functions recognize if it's error/tx and make timestamp decision based on that
- In Python, `X-Sentry-Auth` was causing "multiple authorization payloads requested" so maybe it was used for Python errors? it was not in use on javascript errors. it was in use for python errors before this PR but didn't cause problems.
- logging convention, for now
- test/db.py now takes Id of item in sqlite

## Note / TODO
- the "new" start/end timestamps are rounded off to the 7th decimal place. The javasript transactions by sdk have a mix of 4,5,6,7 decimals places. So I'm defaulting to 7.

- time zone woes
```
// is PST, or wherever you're running this from
timestamp := time.Now()
// is GMT, so not same as timezone you're running this from
oldTimestamp := bodyInterface["timestamp"].(string)
```

- make sure errors still work (js, python, updateTimestamp, headers)

- The Parent/trace and Spans could use a generalized function since same code exists for both right now.