### PR TITLE
Transactions in Python - Update Timestamps

### DIFF
--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -228,13 +228,13 @@ func python(event Event) {
 		request.Header.Set(v, headerInterface[v].(string))
 	}
 
-	// response, requestErr := httpClient.Do(request)
-	// if requestErr != nil { fmt.Println(requestErr) }
+	response, requestErr := httpClient.Do(request)
+	if requestErr != nil { fmt.Println(requestErr) }
 
-	// responseData, responseDataErr := ioutil.ReadAll(response.Body)
-	// if responseDataErr != nil { log.Fatal(responseDataErr) }
+	responseData, responseDataErr := ioutil.ReadAll(response.Body)
+	if responseDataErr != nil { log.Fatal(responseDataErr) }
 
-	// fmt.Printf("\n> python event response: %v\n", string(responseData))
+	fmt.Printf("\n> python event response: %v\n", string(responseData))
 }
 
 func replaceEventId(bodyInterface map[string]interface{}) map[string]interface{} {

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -206,7 +206,6 @@ func python(event Event) {
 		bodyInterface = updateTimestamp(bodyInterface, "python")
 	}
 	if (event._type == "transaction") {
-		fmt.Println(bodyInterface)
 		bodyInterface = updateTimestamps(bodyInterface, "python")
 	}
 	
@@ -288,7 +287,21 @@ func updateTimestamp(bodyInterface map[string]interface{}, platform string) map[
 // 'start_timestamp' is only present in transactions. 'timestamp' represents end of the span/trace
 // data.contexts.trace.span_id is the Parent. data["start_timestamp"] data["timestamp"]
 func updateTimestamps(data map[string]interface{}, platform string) map[string]interface{} {
-	
+	if (platform == "python") {
+		fmt.Printf("> py updateTimestamps parent start_timestamp before %v (%T) \n", data["start_timestamp"], data["start_timestamp"])
+		fmt.Printf("> py updateTimestamps parent       timestamp before %v (%T) \n", data["timestamp"], data["timestamp"])
+		// PARENT TRACE
+		// ???
+		// parentStartTimestamp := decimal.NewFromFloat(data["start_timestamp"].(float64))
+		// parentEndTimestamp := decimal.NewFromFloat(data["timestamp"].(float64))		
+		// parentDifference := parentEndTimestamp.Sub(parentStartTimestamp)
+		t, _ := time.Parse(time.RFC3339Nano, data["start_timestamp"].(string))
+		fmt.Println("******* t ", t)
+
+		// unixTimestampString := fmt.Sprint(time.Now().UnixNano())
+		// newParentStartTimestamp, _ := decimal.NewFromString(unixTimestampString[:10] + "." + unixTimestampString[10:])
+		// SPANS
+	}
 	if (platform == "javascript") {
 		// PARENT TRACE
 		// in sqlite it was float64, not a string. or rather, Go is making it a float64 upon reading from db? not sure
@@ -367,15 +380,7 @@ func updateTimestamps(data map[string]interface{}, platform string) map[string]i
 		// SUCCESS - it updated by reference
 		// before - 1591467416.0387652
 		// after  - 1591476953.491206959
-
 	} 
-	
-	// if (platform == "python") {
-
-	// }
-
-	// fmt.Println("       timestamp after",data["timestamp"])
-	// fmt.Println(" start_timestamp after",data["start_timestamp"])
 	return data
 }
 

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -303,8 +303,8 @@ func updateTimestamps(data map[string]interface{}, platform string) map[string]i
 
 		unixTimestampString := fmt.Sprint(time.Now().UnixNano())
 		newParentStartTimestamp, _ := decimal.NewFromString(unixTimestampString[:10] + "." + unixTimestampString[10:])
-		// fmt.Println("\nyyyyyyyyyyy newParentStartTimestamp", newParentStartTimestamp)
 		newParentEndTimestamp := newParentStartTimestamp.Add(parentDifference)
+		// fmt.Println("\nyyyyyyyyyyy newParentStartTimestamp", newParentStartTimestamp)
 
 		if (newParentEndTimestamp.Sub(newParentStartTimestamp).Equal(parentDifference)) {
 			fmt.Printf("\nTRUE - parent PYTHON")
@@ -330,12 +330,17 @@ func updateTimestamps(data map[string]interface{}, platform string) map[string]i
 			fmt.Printf("\n> py updatetimestamps SPAN       timestamp before %v (%T)\n", sp["timestamp"]	, sp["timestamp"])
 			t1, _ := time.Parse(time.RFC3339Nano, sp["start_timestamp"].(string))
 			t2, _ := time.Parse(time.RFC3339Nano, sp["timestamp"].(string))
-			// fmt.Println("******* t1 ", t1.UnixNano())
-			// fmt.Println("******* t2 ", t2.UnixNano())
-			
-			spanStartTimestamp := decimal.NewFromInt(t1.UnixNano())
-			spanEndTimestamp := decimal.NewFromInt(t2.UnixNano())
+
+			t1String := fmt.Sprint(t1.UnixNano())
+			t2String := fmt.Sprint(t2.UnixNano())
+
+			// INT's, but we need subtraction on the decimals via Floats
+			// spanStartTimestamp := decimal.NewFromInt(t1.UnixNano())
+			// spanEndTimestamp := decimal.NewFromInt(t2.UnixNano())
+			spanStartTimestamp, _ := decimal.NewFromString(t1String[:10] + "." + t1String[10:])
+			spanEndTimestamp, _ := decimal.NewFromString(t2String[:10] + "." + t2String[10:])
 			spanDifference := spanEndTimestamp.Sub(spanStartTimestamp)
+			// fmt.Println("\nxxxxxxxxxxx spanDifference", spanDifference)
 			
 			spanToParentDifference := spanStartTimestamp.Sub(parentStartTimestamp)
 		
@@ -343,6 +348,7 @@ func updateTimestamps(data map[string]interface{}, platform string) map[string]i
 			unixTimestampDecimal, _ := decimal.NewFromString(unixTimestampString[:10] + "." + unixTimestampString[10:])
 			newSpanStartTimestamp := unixTimestampDecimal.Add(spanToParentDifference)
 			newSpanEndTimestamp := newSpanStartTimestamp.Add(spanDifference)
+			// fmt.Println("\nyyyyyyyyyyy newSpanStartTimestamp", newSpanStartTimestamp)
 		
 			if (newSpanEndTimestamp.Sub(newSpanStartTimestamp).Equal(spanDifference)) {
 				fmt.Printf("TRUE - span PYTHON")
@@ -383,9 +389,7 @@ func updateTimestamps(data map[string]interface{}, platform string) map[string]i
 			fmt.Print(newParentEndTimestamp.Sub(newParentStartTimestamp))
 		}
 
-		// is okay that this is an instance of the 'decimal' package and no longer Float64? 
-		// need [:7] (Roudn()) still ???????
-		// n1, _ := newParentStartTimestamp.Round(7).Float64()
+		// better to put as Float65 before serialization. also keep 7 decimal places.
 		data["start_timestamp"], _ = newParentStartTimestamp.Round(7).Float64()
 		data["timestamp"], _ = newParentEndTimestamp.Round(7).Float64()
 
@@ -400,14 +404,11 @@ func updateTimestamps(data map[string]interface{}, platform string) map[string]i
 		// fmt.Printf("\n> ***************** before ", decimal.NewFromFloat(firstSpan["start_timestamp"].(float64)))
 
 		// SPANS
-		// for _, span := range data["spans"].(map[string]float64) {
 		for _, span := range data["spans"].([]interface{}) {
-			// give it a type
 			sp := span.(map[string]interface{})
 			
 			fmt.Printf("\n> js updatetimestamps SPAN start_timestamp before %v (%T)", decimal.NewFromFloat(sp["start_timestamp"].(float64)), decimal.NewFromFloat(sp["start_timestamp"].(float64)))
 			fmt.Printf("\n> js updatetimestamps SPAN       timestamp before %v (%T)\n", decimal.NewFromFloat(sp["timestamp"].(float64))	, decimal.NewFromFloat(sp["timestamp"].(float64)))
-
 			
 			spanStartTimestamp := decimal.NewFromFloat(sp["start_timestamp"].(float64))
 			spanEndTimestamp := decimal.NewFromFloat(sp["timestamp"].(float64))		

--- a/test/db.py
+++ b/test/db.py
@@ -61,7 +61,7 @@ try:
             'id': sqlite_id,
             'platform': event_name,
             'type': event_type,
-            'buffer': json.loads(buffer), # TODO add flag for 'include body' in query
+            # 'buffer': json.loads(buffer), # TODO add flag for 'include body' in query
             'headers': json.loads(headers)
         }
         print(json.dumps(output, indent=2))

--- a/test/db.py
+++ b/test/db.py
@@ -61,7 +61,7 @@ try:
             'id': sqlite_id,
             'platform': event_name,
             'type': event_type,
-            # 'buffer': json.loads(buffer), # TODO add flag for 'include body' in query
+            'buffer': json.loads(buffer), # TODO add flag for 'include body' in query
             'headers': json.loads(headers)
         }
         print(json.dumps(output, indent=2))


### PR DESCRIPTION
## Overall
similar work done as in https://github.com/thinkocapo/undertaker/pull/55

## Done
Big difference with python is that the SDK puts a timestamp of `"2020-06-07T01:41:56.331314Z"` instead of `1591500709.4021327` (javascript sdk)

So, parse this into one of go's `Time` objects using `time.RFC3339Nano` and then convert to format 
 `15915007094021327` then add the decimal before the milliseconds like `1591500709.4021327`, so now you can perform arithmetic on the timestamps as `float64`'s instead of `int`'s (which don't have the decimal points.


## Next
- test that Errors still work
- re-factor with timestamps, DRY out the code
- add undertaker tag
- re-factor overall program flow so that the functions `javascript()` and `python()` are not dead-ends, since they end up doing the same thing. Make them return functions which get executed from the `main` function.