### PR TITLE
Error test

### DIFF
--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -228,37 +228,12 @@ func python(event Event) {
 
 // used for ERRORS
 // js timestamps https://github.com/getsentry/sentry-javascript/pull/2575
+// "1590946750" but as of 06/07/2020 the 'timestamp' property comes in as <nil>. do not need to set the extra decimals
+// "2020-05-31T23:55:11.807534Z" for python
+// new timestamp format is same for js/python even though was different format on the way in
 func updateTimestamp(bodyInterface map[string]interface{}, platform string) map[string]interface{} {
-	fmt.Println("> Error timestamp before", bodyInterface["timestamp"]) // nil for js errors, despite being on latest sdk as of 05/30/2020
-	
-	// "1590946750" but as of 06/07/2020 the 'timestamp' property comes in as <nil>. do not need to set the extra decimals
-	if (platform == "javascript") {
-		bodyInterface["timestamp"] = time.Now().Unix() 
-	}
-
-	// "2020-05-31T23:55:11.807534Z"
-	if (platform == "python") {
-		// adding .UTC() seems to have fixed it, so appears at top of Discover event feed. Universal Coordinated Time
-		// timestamp := time.Now().UTC() // HERE
-
-		// when using timestamp := time.Now() and no "Europe/London" like above, the 'after' timestamp ends up being before the 'before', and so it doesn't display on top of your Discover  eventfeed
-		// timestamp before 2020-06-02T00:09:51.365214Z
-		// timestamp after  2020-06-01T17:12:26.365214Z
-		
-		// Trying to get GMT, basically just want the error to be top-most in your Discover feed
-		// Displays 2 hours ahead. so could subtract 2 hours somewhere?
-		// loc, _ := time.LoadLocation("Europe/London")
-		// timestamp := time.Now().In(loc)
-		
-		// HERE
-		// oldTimestamp := bodyInterface["timestamp"].(string)
-		// newTimestamp := timestamp.Format("2006-01-02") + "T" + timestamp.Format("15:04:05")
-		// bodyInterface["timestamp"] = newTimestamp + oldTimestamp[19:]
-
-		// discovered that this works...
-		bodyInterface["timestamp"] = time.Now().Unix() 
-	}
-
+	fmt.Println("> Error timestamp before", bodyInterface["timestamp"])
+	bodyInterface["timestamp"] = time.Now().Unix() 
 	fmt.Println("> Error timestamp after ", bodyInterface["timestamp"])
 	return bodyInterface
 }

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -229,7 +229,7 @@ func python(event Event) {
 // used for ERRORS
 // js timestamps https://github.com/getsentry/sentry-javascript/pull/2575
 func updateTimestamp(bodyInterface map[string]interface{}, platform string) map[string]interface{} {
-	fmt.Println(" timestamp before", bodyInterface["timestamp"]) // nil for js errors, despite being on latest sdk as of 05/30/2020
+	fmt.Println("> timestamp before", bodyInterface["timestamp"]) // nil for js errors, despite being on latest sdk as of 05/30/2020
 	
 	// "1590946750"
 	// TODO - works? or need the extra decimals (millseconds) at the end
@@ -251,7 +251,7 @@ func updateTimestamp(bodyInterface map[string]interface{}, platform string) map[
 		// timestamp after  2020-06-01T17:12:26.365214Z
 	}
 
-	fmt.Println("  timestamp after", bodyInterface["timestamp"])
+	fmt.Println("> timestamp after", bodyInterface["timestamp"])
 	return bodyInterface
 }
 
@@ -359,7 +359,12 @@ func replaceEventId(bodyInterface map[string]interface{}) map[string]interface{}
 	return bodyInterface
 }
 
+// Python Error Events do not have 'tags' attribute, if no custom tags were set...? "Sometimes there's no tags attribute yet (typically if no custom tags were set, at least for ERr EVents". Transactions come with a few tags by default, by the sdk.
 func undertake(bodyInterface map[string]interface{}) {
+	if (bodyInterface["tags"] == nil) {
+		fmt.Println("*************** No tags ***************")
+		bodyInterface["tags"] = make(map[string]interface{})
+	}
 	tags := bodyInterface["tags"].(map[string]interface{})
 	tags["undertaker"] = "is_here"
 }

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -239,7 +239,7 @@ func updateTimestamp(bodyInterface map[string]interface{}, platform string) map[
 	// "2020-05-31T23:55:11.807534Z"
 	if (platform == "python") {
 		// adding .UTC() seems to have fixed it, so appears at top of Discover event feed. Universal Coordinated Time
-		timestamp := time.Now().UTC()
+		// timestamp := time.Now().UTC() // HERE
 
 		// when using timestamp := time.Now() and no "Europe/London" like above, the 'after' timestamp ends up being before the 'before', and so it doesn't display on top of your Discover  eventfeed
 		// timestamp before 2020-06-02T00:09:51.365214Z
@@ -250,9 +250,13 @@ func updateTimestamp(bodyInterface map[string]interface{}, platform string) map[
 		// loc, _ := time.LoadLocation("Europe/London")
 		// timestamp := time.Now().In(loc)
 		
-		oldTimestamp := bodyInterface["timestamp"].(string)
-		newTimestamp := timestamp.Format("2006-01-02") + "T" + timestamp.Format("15:04:05")
-		bodyInterface["timestamp"] = newTimestamp + oldTimestamp[19:]
+		// HERE
+		// oldTimestamp := bodyInterface["timestamp"].(string)
+		// newTimestamp := timestamp.Format("2006-01-02") + "T" + timestamp.Format("15:04:05")
+		// bodyInterface["timestamp"] = newTimestamp + oldTimestamp[19:]
+
+		// discovered that this works...
+		bodyInterface["timestamp"] = time.Now().Unix() 
 	}
 
 	fmt.Println("> Error timestamp after ", bodyInterface["timestamp"])

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -231,8 +231,7 @@ func python(event Event) {
 func updateTimestamp(bodyInterface map[string]interface{}, platform string) map[string]interface{} {
 	fmt.Println("> Error timestamp before", bodyInterface["timestamp"]) // nil for js errors, despite being on latest sdk as of 05/30/2020
 	
-	// "1590946750"
-	// TODO - works? or need the extra decimals (millseconds) at the end
+	// "1590946750" but as of 06/07/2020 the 'timestamp' property comes in as <nil>. do not need to set the extra decimals
 	if (platform == "javascript") {
 		bodyInterface["timestamp"] = time.Now().Unix() 
 	}

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -297,12 +297,10 @@ func updateTimestamps(data map[string]interface{}, platform string) map[string]i
 	newParentStartTimestamp, _ := decimal.NewFromString(unixTimestampString[:10] + "." + unixTimestampString[10:])
 	newParentEndTimestamp := newParentStartTimestamp.Add(parentDifference)
 
-	if (newParentEndTimestamp.Sub(newParentStartTimestamp).Equal(parentDifference)) {
-		// fmt.Printf("\nTRUE - parent BOTH")
-	} else {
-		fmt.Printf("\nFALSE - parent BOTH")
-		fmt.Print(newParentEndTimestamp.Sub(newParentStartTimestamp))
+	if (!newParentEndTimestamp.Sub(newParentStartTimestamp).Equal(parentDifference)) {
+		fmt.Printf("\nFALSE - parent BOTH", newParentEndTimestamp.Sub(newParentStartTimestamp))
 	}
+
 	data["start_timestamp"], _ = newParentStartTimestamp.Round(7).Float64()
 	data["timestamp"], _ = newParentEndTimestamp.Round(7).Float64()
 
@@ -342,12 +340,10 @@ func updateTimestamps(data map[string]interface{}, platform string) map[string]i
 		newSpanStartTimestamp := unixTimestampDecimal.Add(spanToParentDifference)
 		newSpanEndTimestamp := newSpanStartTimestamp.Add(spanDifference)
 	
-		if (newSpanEndTimestamp.Sub(newSpanStartTimestamp).Equal(spanDifference)) {
-			// fmt.Printf("TRUE - span BOTH")
-		} else {
-			fmt.Printf("\nFALSE - span BOTH")
-			fmt.Print(newSpanEndTimestamp.Sub(newSpanStartTimestamp))
+		if (!newSpanEndTimestamp.Sub(newSpanStartTimestamp).Equal(spanDifference)) {
+			fmt.Printf("\nFALSE - span BOTH", newSpanEndTimestamp.Sub(newSpanStartTimestamp))
 		}
+
 		sp["start_timestamp"], _ = newSpanStartTimestamp.Round(7).Float64()
 		sp["timestamp"], _ = newSpanEndTimestamp.Round(7).Float64()
 

--- a/python/proxy.py
+++ b/python/proxy.py
@@ -80,6 +80,7 @@ def forward():
     print('> FORWARD')
 
     # TODO https://github.com/thinkocapo/undertaker/issues/48
+    # TODO exception.platform may have been available, as well as exception.sdk
     def make(headers):
         request_headers = {}
         user_agent = request.headers.get('User-Agent').lower()

--- a/test/db.py
+++ b/test/db.py
@@ -37,7 +37,9 @@ try:
         # cur.execute("SELECT * FROM events")
 
         rows = cur.fetchall()
+        # TODO - update with attribute/metadata like a count* from query, as this isn't accurate if only selecing 1 by Id
         print('TOTAL ROWS: ', len(rows))
+
         # print('Most recent sqlite id:', rows[len(rows)-1][0]) # is latest??
  
         # TODO - iterate through all rows and print


### PR DESCRIPTION
## Done
- deprecated updateTimestamps (Performance Tracing) function in favor of better one
- same updateTimestamp function internals for both Python/Javascript errors now. `time.Now().Unix() ` works fine for assigning to both, even though the formats were different on the way in.
- undertake() function now creates Tags field on the event, if it was missing, as this was needed for javascript errors.

### Learned about js vs python
- 'tags' array is blank of no custom tags were set (check if same happens for js)
- timestamp formats by sdk are different
- something about 'type' or 'platform' getting set.
- timestamp for js error event still blank on the way in, despite https://github.com/getsentry/sentry-javascript/pull/2575?