### PR TITLE
Adjust Spans

### DIFF
--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -201,13 +201,17 @@ func javascript(event Event) {
 		request.Header.Set(v, headerInterface[v].(string))
 	}
 	
-	// response, requestErr := httpClient.Do(request)
-	// if requestErr != nil { fmt.Println(requestErr) }
-
-	// responseData, responseDataErr := ioutil.ReadAll(response.Body)
-	// if responseDataErr != nil { log.Fatal(responseDataErr) }
-
-	// fmt.Printf("\n> javascript event response\n", string(responseData))
+	if !*ignore {
+		response, requestErr := httpClient.Do(request)
+		if requestErr != nil { fmt.Println(requestErr) }
+	
+		responseData, responseDataErr := ioutil.ReadAll(response.Body)
+		if responseDataErr != nil { log.Fatal(responseDataErr) }
+	
+		fmt.Printf("\n> javascript event response\n", string(responseData))
+	} else {
+		fmt.Printf("\n> javascript event IGNORED\n")
+	}
 }
 
 func python(event Event) {

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -198,13 +198,13 @@ func javascript(event Event) {
 		request.Header.Set(v, headerInterface[v].(string))
 	}
 	
-	response, requestErr := httpClient.Do(request)
-	if requestErr != nil { fmt.Println(requestErr) }
+	// response, requestErr := httpClient.Do(request)
+	// if requestErr != nil { fmt.Println(requestErr) }
 
-	responseData, responseDataErr := ioutil.ReadAll(response.Body)
-	if responseDataErr != nil { log.Fatal(responseDataErr) }
+	// responseData, responseDataErr := ioutil.ReadAll(response.Body)
+	// if responseDataErr != nil { log.Fatal(responseDataErr) }
 
-	fmt.Printf("\n> javascript event response\n", string(responseData))
+	// fmt.Printf("\n> javascript event response\n", string(responseData))
 }
 
 func python(event Event) {
@@ -240,13 +240,13 @@ func python(event Event) {
 		request.Header.Set(v, headerInterface[v].(string))
 	}
 
-	response, requestErr := httpClient.Do(request)
-	if requestErr != nil { fmt.Println(requestErr) }
+	// response, requestErr := httpClient.Do(request)
+	// if requestErr != nil { fmt.Println(requestErr) }
 
-	responseData, responseDataErr := ioutil.ReadAll(response.Body)
-	if responseDataErr != nil { log.Fatal(responseDataErr) }
+	// responseData, responseDataErr := ioutil.ReadAll(response.Body)
+	// if responseDataErr != nil { log.Fatal(responseDataErr) }
 
-	fmt.Printf("\n> python event response: %v\n", string(responseData))
+	// fmt.Printf("\n> python event response: %v\n", string(responseData))
 }
 
 // used for ERRORS
@@ -331,7 +331,8 @@ func updateTimestamps(data map[string]interface{}, platform string) map[string]i
 
 		spanDifference := spanEndTimestamp.Sub(spanStartTimestamp)
 		spanToParentDifference := spanStartTimestamp.Sub(parentStartTimestamp)
-	
+		
+		// should use newParentStartTimestamp instead of spanStartTimestamp?
 		unixTimestampString := fmt.Sprint(time.Now().UnixNano())
 		unixTimestampDecimal, _ := decimal.NewFromString(unixTimestampString[:10] + "." + unixTimestampString[10:])
 		newSpanStartTimestamp := unixTimestampDecimal.Add(spanToParentDifference)


### PR DESCRIPTION
## Goal
Adjust the parentDifference/spanDifference between .01 and .2 (1% and 20% difference) so the 'end timestamp' always shift the same amount. Because, you don't want to make the Parent Trace wider if you don't make the spans wider (as you'd have a gap between end of last span and end of the parent trace).

Works, the Transaction Duration is no longer the same every time:
![image](https://user-images.githubusercontent.com/8920574/85488940-086ea180-b584-11ea-8eef-55b8a13f3a0d.png)

## Testing/Results
Before adding a percentage "randomization" of 1% - 20%, it looked like this:
![image](https://user-images.githubusercontent.com/8920574/85487046-a82a3080-b580-11ea-9da6-0fe6ae1b831a.png)
https://sentry.io/organizations/testorg-az/discover/flask:cf0a042d207544cc9ef7335aacfa3812/?field=title&field=event.type&field=project&field=user&field=timestamp&name=All+Events&project=1316515&query=&sort=-timestamp&statsPeriod=24h&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1

After adding a percentage "randomization", **9%** in this case:
![image](https://user-images.githubusercontent.com/8920574/85487123-d60f7500-b580-11ea-9d1a-398b7eac4999.png)
https://sentry.io/organizations/testorg-az/discover/flask:555ce19cac454fd781406102720a0e07/?field=title&field=event.type&field=project&field=user&field=timestamp&name=All+Events&project=1316515&query=&sort=-timestamp&statsPeriod=24h&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1

After adding a percentage "randomization", **19%** in this case:
![image](https://user-images.githubusercontent.com/8920574/85487161-ed4e6280-b580-11ea-9bf1-7a088260149f.png)
https://sentry.io/organizations/testorg-az/discover/flask:46f436529f1a410ea58685a45a5b5138/?field=title&field=event.type&field=project&field=user&field=timestamp&name=All+Events&project=1316515&query=&sort=-timestamp&statsPeriod=24h&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1

### Notes
Identify the end time / delta is same every time, in Discover, put Discover link here:
`TRANSACTION.DURATION` property is how long the Parent Trace transaction took
get_tools 3.17s
https://sentry.io/organizations/testorg-az/discover/results/?field=title&field=project&field=event.type&field=transaction.duration&field=timestamp&name=All+Events&query=get_tools+event.type%3Atransaction+project%3Aflask&sort=timestamp&statsPeriod=24h&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1

`AVG(TRANSACTION.DURATION)` is a count/aggregation so it will group all of those transactions into a single row
https://sentry.io/organizations/testorg-az/discover/results/?field=title&field=project&field=event.type&field=avg%28transaction.duration%29&name=All+Events&query=event.type%3Atransaction+get_tools&sort=-title&statsPeriod=24h&widths=-1&widths=-1&widths=-1&widths=-1

also added a cli flag `-i` for ignoring Sending Event to Sentry, which is good for testing.
### Todo
1.
Adjust the rate in negative percentage too. could decide to do `.Sub` with the amount instead of `.Add` which it's doing now. Make this decision based on a coin flip (yet another random number!?) or some property in the number (e.g. use modulo).

**Edit** don't need this TODO, because they're all going to average out anyways. The first one recorded (to database) will just end up being the shortest, but as you Randomize every time, it will make it appear like the true 'average' or Median was in fact a longer/wider one.

2.
Python /checkout transaction had a lot of processing errors? Why? couldn't view them. Re-test this before running cronjob again.