### PR TITLE
Decode event Refactor

### DIFF
--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -156,9 +156,7 @@ func decodeEvent(event Event) (map[string]interface{}, Timestamper, BodyEncoder,
 			return body, updateTimestamp, pyEncoder, storeEndpointPython
 	}
 	// TODO could put encoder and storeEndpoint in a separate function?
-	// parsing body, updating eventId and timestamps
-	// vs
-	// encoder and storeEndpoint
+	// parsing body, updating eventId and timestamps vs. encoder and storeEndpoint
 	// ^ timestamp+encoder are only things decided in this decodeEvent
 
 }
@@ -224,111 +222,6 @@ func main() {
 	}
 	rows.Close()
 }
-
-// func javascript(event Event) {
-// 	fmt.Sprintf("> JAVASCRIPT %v %v", event.name, event._type)
-	
-// 	bodyInterface := unmarshalJSON(event.bodyBytes)
-// 	bodyInterface = replaceEventId(bodyInterface)
-
-// 	if (event._type == "error") {
-// 		bodyInterface = updateTimestamp(bodyInterface)
-// 	}
-// 	if (event._type == "transaction") {
-// 		bodyInterface = updateTimestamps(bodyInterface, "javascript")
-// 		if (bodyInterface["transaction"] == "http://localhost:5000/") {
-// 			bodyInterface["transaction"] = "http://toolstoredemo.com/"
-
-// 			request := bodyInterface["request"].(map[string]interface{})
-// 			request["url"] = "http://toolstoredemo.com/"
-
-// 			tags := bodyInterface["tags"].(map[string]interface{})
-// 			tags["url"] = "http://toolstoredemo.com/"
-
-// 			spans := bodyInterface["spans"].([]interface{})
-// 			for _, v1 := range spans {
-// 				v := v1.(map[string]interface{})
-// 				if (v["span_id"] == "9cbd476918dcc9b4") {
-// 					v["description"] = "GET http://toolstoredemo.com/tools"
-// 				}
-// 			}
-// 		}
-// 	}
-
-// 	undertake(bodyInterface)
-
-// 	bodyBytesPost := marshalJSON(bodyInterface)
-	
-// 	SENTRY_URL = projects["javascript"].storeEndpoint()
-// 	// fmt.Printf("> storeEndpoint %v", SENTRY_URL)
-
-// 	request, errNewRequest := http.NewRequest("POST", SENTRY_URL, bytes.NewReader(bodyBytesPost))
-// 	if errNewRequest != nil { log.Fatalln(errNewRequest) }
-	
-// 	headerInterface := unmarshalJSON(event.headers)
-// 	for _, v := range [4]string{"Accept-Encoding","Content-Length","Content-Type","User-Agent"} {
-// 		request.Header.Set(v, headerInterface[v].(string))
-// 	}
-	
-// 	if !*ignore {
-// 		response, requestErr := httpClient.Do(request)
-// 		if requestErr != nil { fmt.Println(requestErr) }
-	
-// 		responseData, responseDataErr := ioutil.ReadAll(response.Body)
-// 		if responseDataErr != nil { log.Fatal(responseDataErr) }
-	
-// 		fmt.Printf("\n> javascript event response\n", string(responseData))
-// 	} else {
-// 		fmt.Printf("\n> javascript event IGNORED\n")
-// 	}
-// }
-
-// func python(event Event) {
-// 	fmt.Sprintf("> PYTHON %v %v", event.name, event._type)
-// 	// bodyBytes := decodeGzip(bodyBytesCompressed) no more, because done on its way into the database
-// 	bodyInterface := unmarshalJSON(event.bodyBytes)
-// 	bodyInterface = replaceEventId(bodyInterface)
-
-// 	if (event._type == "error") {
-// 		bodyInterface = updateTimestamp(bodyInterface)
-// 	}
-// 	if (event._type == "transaction") {
-// 		// bodyInterface = updateTimestamps3(bodyInterface, decimal.NewFromString)
-// 		bodyInterface = updateTimestamps(bodyInterface, "python")
-// 	}
-
-// 	undertake(bodyInterface)
-	
-// 	bodyBytesPost := marshalJSON(bodyInterface)
-// 	buf := encodeGzip(bodyBytesPost)
-	
-// 	// TODO control the project from cli, which you want to send to
-// 	SENTRY_URL = projects["python"].storeEndpoint()
-// 	fmt.Printf("> storeEndpoint %v", SENTRY_URL)
-
-// 	request, errNewRequest := http.NewRequest("POST", SENTRY_URL, &buf)
-// 	if errNewRequest != nil { log.Fatalln(errNewRequest) }
-
-// 	headerInterface := unmarshalJSON(event.headers)
-
-// 	// Including X-Sentry-Auth causes, "multiple authorization payloads requested". Why was it being used at one point here? Was it needed for JS errors? It's not used for transactions
-// 	for _, v := range [5]string{"Accept-Encoding","Content-Length","Content-Encoding","Content-Type","User-Agent"} {
-// 		request.Header.Set(v, headerInterface[v].(string))
-// 	}
-
-// 	if !*ignore {
-// 		response, requestErr := httpClient.Do(request)
-// 		if requestErr != nil { fmt.Println(requestErr) }
-
-// 		responseData, responseDataErr := ioutil.ReadAll(response.Body)
-// 		if responseDataErr != nil { log.Fatal(responseDataErr) }
-
-// 		fmt.Printf("\n> python event response: %v\n", string(responseData))
-// 	} else {
-// 		fmt.Printf("\n> python event IGNORED\n")
-// 	}
-	
-// }
 
 // used for ERRORS
 // js timestamps https://github.com/getsentry/sentry-javascript/pull/2575

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -165,13 +165,13 @@ func decodeEvent(event Event) (map[string]interface{}, Timestamper, BodyEncoder,
 func makeRequest(requestBody []byte, requestHeaders map[string]interface{}, storeEndpoint) *Request{
 	request, errNewRequest := http.NewRequest("POST", storeEndpoint, requestBody) // &buf
 	if errNewRequest != nil { log.Fatalln(errNewRequest) }
-
+	
 	// headerInterface := unmarshalJSON(event.headers)
-	// TODO
+
+	// TODO - headers are map[string]string that need be iterated through
 	for _, v := range headers {
 		request.Header.Set(v, headerInterface[v].(string))
 	}
-
 	return request
 }
 
@@ -225,110 +225,110 @@ func main() {
 	rows.Close()
 }
 
-func javascript(event Event) {
-	fmt.Sprintf("> JAVASCRIPT %v %v", event.name, event._type)
+// func javascript(event Event) {
+// 	fmt.Sprintf("> JAVASCRIPT %v %v", event.name, event._type)
 	
-	bodyInterface := unmarshalJSON(event.bodyBytes)
-	bodyInterface = replaceEventId(bodyInterface)
+// 	bodyInterface := unmarshalJSON(event.bodyBytes)
+// 	bodyInterface = replaceEventId(bodyInterface)
 
-	if (event._type == "error") {
-		bodyInterface = updateTimestamp(bodyInterface)
-	}
-	if (event._type == "transaction") {
-		bodyInterface = updateTimestamps(bodyInterface, "javascript")
-		if (bodyInterface["transaction"] == "http://localhost:5000/") {
-			bodyInterface["transaction"] = "http://toolstoredemo.com/"
+// 	if (event._type == "error") {
+// 		bodyInterface = updateTimestamp(bodyInterface)
+// 	}
+// 	if (event._type == "transaction") {
+// 		bodyInterface = updateTimestamps(bodyInterface, "javascript")
+// 		if (bodyInterface["transaction"] == "http://localhost:5000/") {
+// 			bodyInterface["transaction"] = "http://toolstoredemo.com/"
 
-			request := bodyInterface["request"].(map[string]interface{})
-			request["url"] = "http://toolstoredemo.com/"
+// 			request := bodyInterface["request"].(map[string]interface{})
+// 			request["url"] = "http://toolstoredemo.com/"
 
-			tags := bodyInterface["tags"].(map[string]interface{})
-			tags["url"] = "http://toolstoredemo.com/"
+// 			tags := bodyInterface["tags"].(map[string]interface{})
+// 			tags["url"] = "http://toolstoredemo.com/"
 
-			spans := bodyInterface["spans"].([]interface{})
-			for _, v1 := range spans {
-				v := v1.(map[string]interface{})
-				if (v["span_id"] == "9cbd476918dcc9b4") {
-					v["description"] = "GET http://toolstoredemo.com/tools"
-				}
-			}
-		}
-	}
+// 			spans := bodyInterface["spans"].([]interface{})
+// 			for _, v1 := range spans {
+// 				v := v1.(map[string]interface{})
+// 				if (v["span_id"] == "9cbd476918dcc9b4") {
+// 					v["description"] = "GET http://toolstoredemo.com/tools"
+// 				}
+// 			}
+// 		}
+// 	}
 
-	undertake(bodyInterface)
+// 	undertake(bodyInterface)
 
-	bodyBytesPost := marshalJSON(bodyInterface)
+// 	bodyBytesPost := marshalJSON(bodyInterface)
 	
-	SENTRY_URL = projects["javascript"].storeEndpoint()
-	// fmt.Printf("> storeEndpoint %v", SENTRY_URL)
+// 	SENTRY_URL = projects["javascript"].storeEndpoint()
+// 	// fmt.Printf("> storeEndpoint %v", SENTRY_URL)
 
-	request, errNewRequest := http.NewRequest("POST", SENTRY_URL, bytes.NewReader(bodyBytesPost))
-	if errNewRequest != nil { log.Fatalln(errNewRequest) }
+// 	request, errNewRequest := http.NewRequest("POST", SENTRY_URL, bytes.NewReader(bodyBytesPost))
+// 	if errNewRequest != nil { log.Fatalln(errNewRequest) }
 	
-	headerInterface := unmarshalJSON(event.headers)
-	for _, v := range [4]string{"Accept-Encoding","Content-Length","Content-Type","User-Agent"} {
-		request.Header.Set(v, headerInterface[v].(string))
-	}
+// 	headerInterface := unmarshalJSON(event.headers)
+// 	for _, v := range [4]string{"Accept-Encoding","Content-Length","Content-Type","User-Agent"} {
+// 		request.Header.Set(v, headerInterface[v].(string))
+// 	}
 	
-	if !*ignore {
-		response, requestErr := httpClient.Do(request)
-		if requestErr != nil { fmt.Println(requestErr) }
+// 	if !*ignore {
+// 		response, requestErr := httpClient.Do(request)
+// 		if requestErr != nil { fmt.Println(requestErr) }
 	
-		responseData, responseDataErr := ioutil.ReadAll(response.Body)
-		if responseDataErr != nil { log.Fatal(responseDataErr) }
+// 		responseData, responseDataErr := ioutil.ReadAll(response.Body)
+// 		if responseDataErr != nil { log.Fatal(responseDataErr) }
 	
-		fmt.Printf("\n> javascript event response\n", string(responseData))
-	} else {
-		fmt.Printf("\n> javascript event IGNORED\n")
-	}
-}
+// 		fmt.Printf("\n> javascript event response\n", string(responseData))
+// 	} else {
+// 		fmt.Printf("\n> javascript event IGNORED\n")
+// 	}
+// }
 
-func python(event Event) {
-	fmt.Sprintf("> PYTHON %v %v", event.name, event._type)
-	// bodyBytes := decodeGzip(bodyBytesCompressed) no more, because done on its way into the database
-	bodyInterface := unmarshalJSON(event.bodyBytes)
-	bodyInterface = replaceEventId(bodyInterface)
+// func python(event Event) {
+// 	fmt.Sprintf("> PYTHON %v %v", event.name, event._type)
+// 	// bodyBytes := decodeGzip(bodyBytesCompressed) no more, because done on its way into the database
+// 	bodyInterface := unmarshalJSON(event.bodyBytes)
+// 	bodyInterface = replaceEventId(bodyInterface)
 
-	if (event._type == "error") {
-		bodyInterface = updateTimestamp(bodyInterface)
-	}
-	if (event._type == "transaction") {
-		// bodyInterface = updateTimestamps3(bodyInterface, decimal.NewFromString)
-		bodyInterface = updateTimestamps(bodyInterface, "python")
-	}
+// 	if (event._type == "error") {
+// 		bodyInterface = updateTimestamp(bodyInterface)
+// 	}
+// 	if (event._type == "transaction") {
+// 		// bodyInterface = updateTimestamps3(bodyInterface, decimal.NewFromString)
+// 		bodyInterface = updateTimestamps(bodyInterface, "python")
+// 	}
 
-	undertake(bodyInterface)
+// 	undertake(bodyInterface)
 	
-	bodyBytesPost := marshalJSON(bodyInterface)
-	buf := encodeGzip(bodyBytesPost)
+// 	bodyBytesPost := marshalJSON(bodyInterface)
+// 	buf := encodeGzip(bodyBytesPost)
 	
-	// TODO control the project from cli, which you want to send to
-	SENTRY_URL = projects["python"].storeEndpoint()
-	fmt.Printf("> storeEndpoint %v", SENTRY_URL)
+// 	// TODO control the project from cli, which you want to send to
+// 	SENTRY_URL = projects["python"].storeEndpoint()
+// 	fmt.Printf("> storeEndpoint %v", SENTRY_URL)
 
-	request, errNewRequest := http.NewRequest("POST", SENTRY_URL, &buf)
-	if errNewRequest != nil { log.Fatalln(errNewRequest) }
+// 	request, errNewRequest := http.NewRequest("POST", SENTRY_URL, &buf)
+// 	if errNewRequest != nil { log.Fatalln(errNewRequest) }
 
-	headerInterface := unmarshalJSON(event.headers)
+// 	headerInterface := unmarshalJSON(event.headers)
 
-	// Including X-Sentry-Auth causes, "multiple authorization payloads requested". Why was it being used at one point here? Was it needed for JS errors? It's not used for transactions
-	for _, v := range [5]string{"Accept-Encoding","Content-Length","Content-Encoding","Content-Type","User-Agent"} {
-		request.Header.Set(v, headerInterface[v].(string))
-	}
+// 	// Including X-Sentry-Auth causes, "multiple authorization payloads requested". Why was it being used at one point here? Was it needed for JS errors? It's not used for transactions
+// 	for _, v := range [5]string{"Accept-Encoding","Content-Length","Content-Encoding","Content-Type","User-Agent"} {
+// 		request.Header.Set(v, headerInterface[v].(string))
+// 	}
 
-	if !*ignore {
-		response, requestErr := httpClient.Do(request)
-		if requestErr != nil { fmt.Println(requestErr) }
+// 	if !*ignore {
+// 		response, requestErr := httpClient.Do(request)
+// 		if requestErr != nil { fmt.Println(requestErr) }
 
-		responseData, responseDataErr := ioutil.ReadAll(response.Body)
-		if responseDataErr != nil { log.Fatal(responseDataErr) }
+// 		responseData, responseDataErr := ioutil.ReadAll(response.Body)
+// 		if responseDataErr != nil { log.Fatal(responseDataErr) }
 
-		fmt.Printf("\n> python event response: %v\n", string(responseData))
-	} else {
-		fmt.Printf("\n> python event IGNORED\n")
-	}
+// 		fmt.Printf("\n> python event response: %v\n", string(responseData))
+// 	} else {
+// 		fmt.Printf("\n> python event IGNORED\n")
+// 	}
 	
-}
+// }
 
 // used for ERRORS
 // js timestamps https://github.com/getsentry/sentry-javascript/pull/2575

--- a/old-event-to-sentry.go
+++ b/old-event-to-sentry.go
@@ -1,23 +1,27 @@
 package main
 
 import (
-	_ "github.com/mattn/go-sqlite3"
 	"bytes"
 	"compress/gzip"
 	"database/sql"
 	"encoding/json"
 	"flag"
 	"fmt"
+
+	_ "github.com/mattn/go-sqlite3"
+
 	// "github.com/buger/jsonparser"
-	"github.com/google/uuid"
-	"github.com/joho/godotenv"
-	"github.com/shopspring/decimal"
 	"io/ioutil"
 	"log"
 	"math/rand"
 	"net/http"
 	"net/url"
 	"os"
+
+	"github.com/google/uuid"
+	"github.com/joho/godotenv"
+	"github.com/shopspring/decimal"
+
 	// "strconv"
 	"strings"
 	"time"
@@ -26,24 +30,24 @@ import (
 var httpClient = &http.Client{}
 
 var (
-	all *bool
-	id *string
-	ignore *bool
-	db *sql.DB
-	dsn DSN
-	SENTRY_URL string 
-	exists bool
-	projects map[string]*DSN
+	all        *bool
+	id         *string
+	ignore     *bool
+	db         *sql.DB
+	dsn        DSN
+	SENTRY_URL string
+	exists     bool
+	projects   map[string]*DSN
 )
 
-type DSN struct { 
-	host string
-	rawurl string
-	key string
+type DSN struct {
+	host      string
+	rawurl    string
+	key       string
 	projectId string
 }
 
-func parseDSN(rawurl string) (*DSN) {
+func parseDSN(rawurl string) *DSN {
 	key := strings.Split(rawurl, "@")[0][7:]
 
 	uri, err := url.Parse(rawurl)
@@ -55,12 +59,12 @@ func parseDSN(rawurl string) (*DSN) {
 		log.Fatal("missing projectId in dsn")
 	}
 	projectId := uri.Path[idx+1:]
-	
+
 	var host string
-	if (strings.Contains(rawurl, "ingest.sentry.io")) {
+	if strings.Contains(rawurl, "ingest.sentry.io") {
 		host = "ingest.sentry.io"
 	}
-	if (strings.Contains(rawurl, "@localhost:")) {
+	if strings.Contains(rawurl, "@localhost:") {
 		host = "localhost:9000"
 	}
 
@@ -76,32 +80,33 @@ func parseDSN(rawurl string) (*DSN) {
 // Could make a DSN field called 'storeEndpoint' and use this function there to assign the value, during parseDSN
 func (d DSN) storeEndpoint() string {
 	var fullurl string
-	if (d.host == "ingest.sentry.io") {
-		fullurl = fmt.Sprint("https://",d.host,"/api/",d.projectId,"/store/?sentry_key=",d.key,"&sentry_version=7")
+	if d.host == "ingest.sentry.io" {
+		fullurl = fmt.Sprint("https://", d.host, "/api/", d.projectId, "/store/?sentry_key=", d.key, "&sentry_version=7")
 	}
-	if (d.host == "localhost:9000") {
-		fullurl = fmt.Sprint("http://",d.host,"/api/",d.projectId,"/store/?sentry_key=",d.key,"&sentry_version=7")
+	if d.host == "localhost:9000" {
+		fullurl = fmt.Sprint("http://", d.host, "/api/", d.projectId, "/store/?sentry_key=", d.key, "&sentry_version=7")
 	}
 	return fullurl
 }
 
 type Event struct {
-	id int
+	id          int
 	name, _type string
-	headers []byte
-	bodyBytes []byte
+	headers     []byte
+	bodyBytes   []byte
 }
+
 func (e Event) String() string {
 	return fmt.Sprintf("\n Event { SqliteId: %d, Platform: %s, Type: %s }\n", e.id, e.name, e._type)
 }
 
 func init() {
 	if err := godotenv.Load(); err != nil {
-        log.Print("No .env file found")
+		log.Print("No .env file found")
 	}
 
 	projects = make(map[string]*DSN)
-	
+
 	// Must use SAAS for AM Performance Transactions as https://github.com/getsentry/sentry's Release 10.0.0 doesn't include Performance yet
 	// projects["javascript"] = parseDSN(os.Getenv("DSN_REACT"))
 	// projects["python"] = parseDSN(os.Getenv("DSN_PYTHON"))
@@ -122,16 +127,16 @@ func init() {
 
 func main() {
 	defer db.Close()
-	
+
 	query := ""
-	if (*id == "") {
+	if *id == "" {
 		query = "SELECT * FROM events ORDER BY id DESC"
 	} else {
 		query = strings.ReplaceAll("SELECT * FROM events WHERE id=?", "?", *id)
 	}
 
 	rows, err := db.Query(query)
-	
+
 	if err != nil {
 		fmt.Println("Failed to load rows", err)
 	}
@@ -140,10 +145,10 @@ func main() {
 		rows.Scan(&event.id, &event.name, &event._type, &event.bodyBytes, &event.headers)
 		fmt.Println(event)
 
-		if (event.name == "javascript") {
+		if event.name == "javascript" {
 			javascript(event)
 		}
-		if (event.name == "python") {
+		if event.name == "python" {
 			python(event)
 		}
 
@@ -158,16 +163,16 @@ func main() {
 
 func javascript(event Event) {
 	fmt.Sprintf("> JAVASCRIPT %v %v", event.name, event._type)
-	
+
 	bodyInterface := unmarshalJSON(event.bodyBytes)
 	bodyInterface = replaceEventId(bodyInterface)
 
-	if (event._type == "error") {
+	if event._type == "error" {
 		bodyInterface = updateTimestamp(bodyInterface)
 	}
-	if (event._type == "transaction") {
+	if event._type == "transaction" {
 		bodyInterface = updateTimestamps(bodyInterface, "javascript")
-		if (bodyInterface["transaction"] == "http://localhost:5000/") {
+		if bodyInterface["transaction"] == "http://localhost:5000/" {
 			bodyInterface["transaction"] = "http://toolstoredemo.com/"
 
 			request := bodyInterface["request"].(map[string]interface{})
@@ -179,7 +184,7 @@ func javascript(event Event) {
 			spans := bodyInterface["spans"].([]interface{})
 			for _, v1 := range spans {
 				v := v1.(map[string]interface{})
-				if (v["span_id"] == "9cbd476918dcc9b4") {
+				if v["span_id"] == "9cbd476918dcc9b4" {
 					v["description"] = "GET http://toolstoredemo.com/tools"
 				}
 			}
@@ -189,25 +194,31 @@ func javascript(event Event) {
 	undertake(bodyInterface)
 
 	bodyBytesPost := marshalJSON(bodyInterface)
-	
+
 	SENTRY_URL = projects["javascript"].storeEndpoint()
 	// fmt.Printf("> storeEndpoint %v", SENTRY_URL)
 
 	request, errNewRequest := http.NewRequest("POST", SENTRY_URL, bytes.NewReader(bodyBytesPost))
-	if errNewRequest != nil { log.Fatalln(errNewRequest) }
-	
+	if errNewRequest != nil {
+		log.Fatalln(errNewRequest)
+	}
+
 	headerInterface := unmarshalJSON(event.headers)
-	for _, v := range [4]string{"Accept-Encoding","Content-Length","Content-Type","User-Agent"} {
+	for _, v := range [4]string{"Accept-Encoding", "Content-Length", "Content-Type", "User-Agent"} {
 		request.Header.Set(v, headerInterface[v].(string))
 	}
-	
+
 	if !*ignore {
 		response, requestErr := httpClient.Do(request)
-		if requestErr != nil { fmt.Println(requestErr) }
-	
+		if requestErr != nil {
+			fmt.Println(requestErr)
+		}
+
 		responseData, responseDataErr := ioutil.ReadAll(response.Body)
-		if responseDataErr != nil { log.Fatal(responseDataErr) }
-	
+		if responseDataErr != nil {
+			log.Fatal(responseDataErr)
+		}
+
 		fmt.Printf("\n> javascript event response\n", string(responseData))
 	} else {
 		fmt.Printf("\n> javascript event IGNORED\n")
@@ -220,45 +231,51 @@ func python(event Event) {
 	bodyInterface := unmarshalJSON(event.bodyBytes)
 	bodyInterface = replaceEventId(bodyInterface)
 
-	if (event._type == "error") {
+	if event._type == "error" {
 		bodyInterface = updateTimestamp(bodyInterface)
 	}
-	if (event._type == "transaction") {
+	if event._type == "transaction" {
 		// bodyInterface = updateTimestamps3(bodyInterface, decimal.NewFromString)
 		bodyInterface = updateTimestamps(bodyInterface, "python")
 	}
 
 	undertake(bodyInterface)
-	
+
 	bodyBytesPost := marshalJSON(bodyInterface)
 	buf := encodeGzip(bodyBytesPost)
-	
+
 	// TODO control the project from cli, which you want to send to
 	SENTRY_URL = projects["python"].storeEndpoint()
 	fmt.Printf("> storeEndpoint %v", SENTRY_URL)
 
 	request, errNewRequest := http.NewRequest("POST", SENTRY_URL, &buf)
-	if errNewRequest != nil { log.Fatalln(errNewRequest) }
+	if errNewRequest != nil {
+		log.Fatalln(errNewRequest)
+	}
 
 	headerInterface := unmarshalJSON(event.headers)
 
 	// Including X-Sentry-Auth causes, "multiple authorization payloads requested". Why was it being used at one point here? Was it needed for JS errors? It's not used for transactions
-	for _, v := range [5]string{"Accept-Encoding","Content-Length","Content-Encoding","Content-Type","User-Agent"} {
+	for _, v := range [5]string{"Accept-Encoding", "Content-Length", "Content-Encoding", "Content-Type", "User-Agent"} {
 		request.Header.Set(v, headerInterface[v].(string))
 	}
 
 	if !*ignore {
 		response, requestErr := httpClient.Do(request)
-		if requestErr != nil { fmt.Println(requestErr) }
+		if requestErr != nil {
+			fmt.Println(requestErr)
+		}
 
 		responseData, responseDataErr := ioutil.ReadAll(response.Body)
-		if responseDataErr != nil { log.Fatal(responseDataErr) }
+		if responseDataErr != nil {
+			log.Fatal(responseDataErr)
+		}
 
 		fmt.Printf("\n> python event response: %v\n", string(responseData))
 	} else {
 		fmt.Printf("\n> python event IGNORED\n")
 	}
-	
+
 }
 
 // used for ERRORS
@@ -268,7 +285,7 @@ func python(event Event) {
 // new timestamp format is same for js/python even though was different format on the way in
 func updateTimestamp(bodyInterface map[string]interface{}) map[string]interface{} {
 	fmt.Println("> Error timestamp before", bodyInterface["timestamp"])
-	bodyInterface["timestamp"] = time.Now().Unix() 
+	bodyInterface["timestamp"] = time.Now().Unix()
 	fmt.Println("> Error timestamp after ", bodyInterface["timestamp"])
 	return bodyInterface
 }
@@ -281,10 +298,10 @@ func updateTimestamp(bodyInterface map[string]interface{}) map[string]interface{
 func updateTimestamps(data map[string]interface{}, platform string) map[string]interface{} {
 	// fmt.Printf("\n> both updateTimestamps PARENT start_timestamp before %v (%T) \n", data["start_timestamp"], data["start_timestamp"])
 	// fmt.Printf("> both updateTimestamps PARENT       timestamp before %v (%T)", data["timestamp"], data["timestamp"])
-	
+
 	var parentStartTimestamp, parentEndTimestamp decimal.Decimal
 	// PYTHON timestamp format is 2020-06-06T04:54:56.636664Z RFC3339Nano
-	if (platform == "python") {	
+	if platform == "python" {
 		parentStart, _ := time.Parse(time.RFC3339Nano, data["start_timestamp"].(string)) // integer?
 		parentEnd, _ := time.Parse(time.RFC3339Nano, data["timestamp"].(string))
 		parentStartTime := fmt.Sprint(parentStart.UnixNano())
@@ -293,19 +310,19 @@ func updateTimestamps(data map[string]interface{}, platform string) map[string]i
 		parentEndTimestamp, _ = decimal.NewFromString(parentEndTime[:10] + "." + parentEndTime[10:])
 	}
 	// JAVASCRIPT timestamp format is 1591419091.4805 to 1591419092.000035
-	if (platform == "javascript") {
+	if platform == "javascript" {
 		// in sqlite it was float64, not a string. or rather, Go is making it a float64 upon reading from db? not sure
 		// make into a 'decimal' class type for logging or else it logs as "1.5914674155654302e+09" instead of 1591467415.5654302
 		parentStartTimestamp = decimal.NewFromFloat(data["start_timestamp"].(float64))
-		parentEndTimestamp = decimal.NewFromFloat(data["timestamp"].(float64))	
+		parentEndTimestamp = decimal.NewFromFloat(data["timestamp"].(float64))
 	}
-	
+
 	// PARENT TRACE
 	// Adjust the parentDifference/spanDifference between .01 and .2 (1% and 20% difference) so the 'end timestamp's always shift the same amount (no gaps at the end)
 	parentDifference := parentEndTimestamp.Sub(parentStartTimestamp)
 	fmt.Printf("\n> parentDifference before", parentDifference)
 	rand.Seed(time.Now().UnixNano())
-	percentage := 0.01 + rand.Float64() * (0.20 - 0.01)
+	percentage := 0.01 + rand.Float64()*(0.20-0.01)
 	fmt.Println("\n> percentage", percentage)
 	rate := decimal.NewFromFloat(percentage)
 	parentDifference = parentDifference.Mul(rate.Add(decimal.NewFromFloat(1)))
@@ -315,7 +332,7 @@ func updateTimestamps(data map[string]interface{}, platform string) map[string]i
 	newParentStartTimestamp, _ := decimal.NewFromString(unixTimestampString[:10] + "." + unixTimestampString[10:])
 	newParentEndTimestamp := newParentStartTimestamp.Add(parentDifference)
 
-	if (!newParentEndTimestamp.Sub(newParentStartTimestamp).Equal(parentDifference)) {
+	if !newParentEndTimestamp.Sub(newParentStartTimestamp).Equal(parentDifference) {
 		fmt.Printf("\nFALSE - parent BOTH", newParentEndTimestamp.Sub(newParentStartTimestamp))
 	}
 
@@ -337,7 +354,7 @@ func updateTimestamps(data map[string]interface{}, platform string) map[string]i
 		// fmt.Printf("\n> both updatetimestamps SPAN       timestamp before %v (%T)\n", sp["timestamp"]	, sp["timestamp"])
 
 		var spanStartTimestamp, spanEndTimestamp decimal.Decimal
-		if (platform == "python") {
+		if platform == "python" {
 			spanStart, _ := time.Parse(time.RFC3339Nano, sp["start_timestamp"].(string))
 			spanEnd, _ := time.Parse(time.RFC3339Nano, sp["timestamp"].(string))
 			spanStartTime := fmt.Sprint(spanStart.UnixNano())
@@ -345,9 +362,9 @@ func updateTimestamps(data map[string]interface{}, platform string) map[string]i
 			spanStartTimestamp, _ = decimal.NewFromString(spanStartTime[:10] + "." + spanStartTime[10:])
 			spanEndTimestamp, _ = decimal.NewFromString(spanEndTime[:10] + "." + spanEndTime[10:])
 		}
-		if (platform == "javascript") {
+		if platform == "javascript" {
 			spanStartTimestamp = decimal.NewFromFloat(sp["start_timestamp"].(float64))
-			spanEndTimestamp = decimal.NewFromFloat(sp["timestamp"].(float64))		
+			spanEndTimestamp = decimal.NewFromFloat(sp["timestamp"].(float64))
 		}
 
 		spanDifference := spanEndTimestamp.Sub(spanStartTimestamp)
@@ -356,14 +373,14 @@ func updateTimestamps(data map[string]interface{}, platform string) map[string]i
 		fmt.Println("> spanDifference after", spanDifference)
 
 		spanToParentDifference := spanStartTimestamp.Sub(parentStartTimestamp)
-		
+
 		// should use newParentStartTimestamp instead of spanStartTimestamp?
 		unixTimestampString := fmt.Sprint(time.Now().UnixNano())
 		unixTimestampDecimal, _ := decimal.NewFromString(unixTimestampString[:10] + "." + unixTimestampString[10:])
 		newSpanStartTimestamp := unixTimestampDecimal.Add(spanToParentDifference)
 		newSpanEndTimestamp := newSpanStartTimestamp.Add(spanDifference)
-	
-		if (!newSpanEndTimestamp.Sub(newSpanStartTimestamp).Equal(spanDifference)) {
+
+		if !newSpanEndTimestamp.Sub(newSpanStartTimestamp).Equal(spanDifference) {
 			fmt.Printf("\nFALSE - span BOTH", newSpanEndTimestamp.Sub(newSpanStartTimestamp))
 		}
 
@@ -380,19 +397,19 @@ func updateTimestamps(data map[string]interface{}, platform string) map[string]i
 }
 
 func replaceEventId(bodyInterface map[string]interface{}) map[string]interface{} {
-	if _, ok := bodyInterface["event_id"]; !ok { 
+	if _, ok := bodyInterface["event_id"]; !ok {
 		log.Print("no event_id on object from DB")
 	}
 	// fmt.Println("> before",bodyInterface["event_id"])
-	var uuid4 = strings.ReplaceAll(uuid.New().String(), "-", "") 
+	var uuid4 = strings.ReplaceAll(uuid.New().String(), "-", "")
 	bodyInterface["event_id"] = uuid4
-	fmt.Println("> event_id after",bodyInterface["event_id"])
+	fmt.Println("> event_id after", bodyInterface["event_id"])
 	return bodyInterface
 }
 
 // Python Error Events do not have 'tags' attribute, if no custom tags were set...? "Sometimes there's no tags attribute yet (typically if no custom tags were set, at least for ERr EVents". Transactions come with a few tags by default, by the sdk.
 func undertake(bodyInterface map[string]interface{}) {
-	if (bodyInterface["tags"] == nil) {
+	if bodyInterface["tags"] == nil {
 		bodyInterface["tags"] = make(map[string]interface{})
 	}
 	tags := bodyInterface["tags"].(map[string]interface{})
@@ -435,8 +452,10 @@ func unmarshalJSON(bytes []byte) map[string]interface{} {
 }
 
 func marshalJSON(bodyInterface map[string]interface{}) []byte {
-	bodyBytes, errBodyBytes := json.Marshal(bodyInterface) 
-	if errBodyBytes != nil { fmt.Println(errBodyBytes)}
+	bodyBytes, errBodyBytes := json.Marshal(bodyInterface)
+	if errBodyBytes != nil {
+		fmt.Println(errBodyBytes)
+	}
 	return bodyBytes
 }
 


### PR DESCRIPTION
main code blocks to show off what was done:
```
body, timestamper, bodyEncoder, headerKeys, storeEndpoint := decodeEvent(event)

		body = replaceEventId(body)
		body = timestamper(body, event.name)

		// Custom Transformations
		undertake(body)

		requestBody := bodyEncoder(body)
		request := buildRequest(requestBody, headerKeys, event.headers, storeEndpoint)
```
and
```
	switch {
	case JAVASCRIPT && TRANSACTION:
		return body, updateTimestamps, jsEncoder, jsHeaders, storeEndpointJavascript
	case JAVASCRIPT && ERROR:
		return body, updateTimestamp, jsEncoder, jsHeaders, storeEndpointJavascript
	case PYTHON && TRANSACTION:
		return body, updateTimestamps, pyEncoder, pyHeaders, storeEndpointPython
	case PYTHON && ERROR:
		return body, updateTimestamp, pyEncoder, pyHeaders, storeEndpointPython
	}
```

left the old version for now under old-event-to-sentry.go