### PR TITLE
Cli dsn db

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,19 @@ SDK's create events and `python/proxy.py` intercepts "undertakes" the events on 
 
 1. Enter your DSN's in `.env`  
 ```
-// for the Tool Store data set (go build -o bin/event-to-sentry-toolstore-gcp *.go)
+// for the Tool Store data set (go build -o bin/event-to-sentry-toolstore *.go)
 DSN_JAVASCRIPT_SAAS=
 DSN_PYTHON_SAAS=
 
 or
 
-// for the Gateway/Microservices/Celery dataset (go build -o bin/event-to-sentry-tracing-example-multiproject *.go)
+// for the Gateway/Microservices/Celery dataset (go build -o bin/event-to-sentry-tracing-example *.go)
 DSN_PYTHON_GATEWAY=
 DSN_PYTHON_DJANGO=
 DSN_PYTHON_CELERY=
+
+// set this here as your default or pass it at runtime using --db=
+SQLITE=
 ```
 
 2. `pip3 install -r ./python/requirements.txt` for the proxy  

--- a/README.md
+++ b/README.md
@@ -1,100 +1,119 @@
 <!-- ![The Undertaker](./img/undertaker-1.png) -->
 # The Undertaker
+The Undertaker a.k.a. Replay is an event traffic replay service.
 
 <img src="./img/undertaker-4.jpeg" width="450" height="300">  
 
-## why and what's happening?  
-Good for test data automation. Do not have to maintain +10 different app and sdk types in Heroku/GCP sending events all the time. Rather, run a single program `event-to-sentry.go` on a cronjob to send those +10 event types for you. It's free. 
+## Why?  
+Stop maintaing +10 different platform SDK's in GCP sending events all the time. Rather, run a single program `event-to-sentry.go` on a cronjob to send all those events for you. It's free. Great for automating test data.
 
 <img src="./img/event-maker-slide-2.001.png" width="450" height="300">  
 
-**STEP1**  
-`event.py` creates sdk events
+**STEP 1**  
+SDK's create events and `python/proxy.py` intercepts "undertakes" the events on their way to Sentry and saves them in sqlite
 
-`flask/proxy.py` undertakes (intercepts) events on their way to Sentry and saves them in sqlite
-
-**STEP2**  
-`event-to-sentry.go` loads events from sqlite and sends them to Sentry, without using an sdk.
+**STEP 2**  
+`event-to-sentry.go` loads the events from sqlite and relpays them to Sentry (no sdk's used in this step)
 
 ## Setup
 
 1. Enter your DSN's in `.env`  
-Both the proxy.py and event-to-sentry.go will use this.
-DSN's from `getsentry/onpremise` do not support transactions as of 07/01/20
 ```
-// go build -o bin/event-to-sentry-toolstore *.go
-DSN_JAVASCRIPT_SAAS
-DSN_PYTHON_SAAS
-```
+// for the Tool Store data set (go build -o bin/event-to-sentry-toolstore-gcp *.go)
+DSN_JAVASCRIPT_SAAS=
+DSN_PYTHON_SAAS=
+
 or
+
+// for the Gateway/Microservices/Celery dataset (go build -o bin/event-to-sentry-tracing-example-multiproject *.go)
+DSN_PYTHON_GATEWAY=
+DSN_PYTHON_DJANGO=
+DSN_PYTHON_CELERY=
 ```
-// go build -o bin/event-to-sentry-tracing-example *.go
-DSN_PYTHON_GATEWAY
-DSN_PYTHON_DJANGO
-DSN_PYTHON_CELERY
+
+2. `pip3 install -r ./python/requirements.txt` for the proxy  
+3.
+
 ```
-2. `pip3 install -r ./python/requirements.txt` for the proxy
-3. `go build -o bin/event-to-sentry-toolstore *.go` or `go build -o bin/event-to-sentry-tracing-example *.go` depending on DSN's in .env
+go build -o bin/event-to-sentry-<name> *.go
+
+// for Tool Store data set (javascrip, pythont, errors+transactions)
+go build -o bin/event-to-sentry-toolstore
+
+// for Gateway/Microservices/Celery dataset (python transactions)
+go build -o bin/event-to-sentry-tracing-example *.go
+```
+
+Note - Transactions are not supported if using DSN's from `getsentry/onpremise` as of 07/08/20
 
 ## Run
-Get your proxy and Sentry instance running first.
 ```
-make proxy
-
-# cd getsentry/onpremise
-docker-compose up
-```
-**STEP1**  
-Send events to proxy... 
-```
-# optional
-python3 event.py
-```
-**STEP2**  
-```
-go build -o bin/event-to-sentry *.go
+./bin/event-to-sentry-<name>
 ./bin/event-to-sentry
 ./bin/event-to-sentry --id=<id>
 ./bin/event-to-sentry --id=<id> -i
 ./bin/event-to-sentry --all
-
-go build -o bin/event-to-sentry-<name> *.go
-./bin/event-to-sentry-<name>
-
 ```
-See your event in Sentry at `localhost:9000`
-
-**Cronjobs**  
-Cronjob on Macbook that sends events in the background
-`crontab -e` to open up your Mac's crontab manager
+or use `--js` `--py` to pass DSN's when running the executable
 ```
+./bin/event-to-sentry --all --db=am-transactions-timeout-sqlite.db
+./bin/event-to-sentry --all --db=<path_to_.db> --js=<javascripti_DSN> --py=<python_DSN>
+```
+
+See your events in Sentry
+
+## Proxy (optional)
+Use the proxy if you want to create your own data set 
+
+1. Get your proxy running
+```
+make proxy
+```
+
+2. Modify your app's DSN so it will point to the proxy. See `python/event.py` for how to do this.
+
+3. Create errors in your app, so the events get sent to the proxy.
+
+4. Check your events saved to the database
+`python3 test/db.py` or make testdb
+
+Note - You can expose the proxy's port 3001 via ngrok, if your apps are in a VPC/network that you can't run the proxy inside of. 
+1. `ngrok http 3001`
+2. put the ngrok address in your app's DSN like:  
+`SENTRY_DSN=https://1f2d7bf845114ba6a5ba19ee07db6800@5b286dac3e72.ngrok.io/3`
+3. now your events will send to the proxy
+
+## Cronjobs
+Macbook's cronjob manager for sending events in the background while you work
+```
+# crontab -l, to list cronjobs
+# crontab -e to open crontab manager
+
 # every minute
-1-59 * * * * cd /Users/wcap/thinkocapo/undertaker && ./bin/event-to-sentry --all
 1-59 * * * * cd /<path>/<to>/undertaker/ && ./event-to-sentry
 
 # every minute, every day of the week M-F
-# * * * * 1-5 cd /Users/wcap/thinkocapo/undertaker && ./bin/event-to-sentry --all
-# * * * * 1-5 cd /<path>/<to>/undertaker/ && ./event-to-sentry --all
+# * * * * 1-5 cd /<path>/<to>/undertaker/ && ./event-to-sentry-<name> --all
 
 # every 5 minutes
-# */5 * * * 1-5 cd /Users/wcap/thinkocapo/undertaker && ./bin/event-to-sentry-neil --all
-# */5 * * * 1-5 cd /<path>/<to>/undertaker/ && ./event-to-sentry --all
-
-# crontab -l, to list cronjobs
+*/5 * * * 1-5 cd /<path>/<to>/undertaker/ && ./event-to-sentry-<name> --all
 ```
 
 https://crontab.guru/
 
 ## Notes
-See `python/event.py` for how to construct the 3 'MODIFIED' DSN types which decide which of the 3 endpoints in `proxy.py` which you can hit. Use any app+sdk with one of these MODIFIED_DSN's following the convention in proxy.py
 
-`python3 test/db.py` is for showing total row count and most recent event.  
-`python3 test/db.py 5` gets the 5th item  
-`python3 test/dby.py 5 -b` gets the 5th item and prints its body  
+#### database
+`python3 test/db.py` shows total event count and most recently saved event.  
+`python3 test/db.py 5` gets the 5th event  
+`python3 test/dby.py 5 -b` gets the 5th event and prints its body  
 
-The timestamp from `go run event-to-sentry.go` is sometimes earlier than today's date
+#### gotcha's
+The timestamp from `go run event-to-sentry.go` is sometimes earlier than today's date and time 
+Use python3 or else else `getvalue()` in `python/event-to-sentry.py` returns wrong data type
 
-Borrowed code from: getsentry/sentry-python, getsentry/sentry-go, goreplay
+#### other
+Borrowed code from: getsentry/sentry-python, getsentry/sentry-go, goreplay, getsentry/gor-middleware
 
 https://develop.sentry.dev/sdk/store for info on the Sentry store endpoint
 
@@ -103,18 +122,11 @@ https://develop.sentry.dev/sdk/event-payloads/ for what a sdk event looks like. 
 6 events in the am-transactions-sqlite.db was 57kb
 19 events tracing-example was 92kb
 
-To use with getsentry/tracing-example, serve the python/proxy.py via `ngrok http 3001` and put the ngrok address in tracing-example's .env like:  
-`SENTRY_DSN=https://1f2d7bf845114ba6a5ba19ee07db6800@5b286dac3e72.ngrok.io/3`
-
 tested on: ubuntu 18.04 LTS, go 1.12.9 linux/amd64, sentry-sdk 0.14.2, flask Python 3.6.9
-
-use python3 or else else `getvalue()` in `event-to-sentry.py` returns wrong data type ¯\_(ツ)_/¯
 
 `python-dotenv` vs `dotenv`
 
 ## Todo
-- pass a DSN's file at run-time, consider db too
-
 - Mobile android errors/crashes/sessions
 - update tracing-example's endpoint names. www.toolstoredmeo.com instead of gcp url
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ make proxy
 4. Check your events saved to the database
 `python3 test/db.py` or make testdb
 
-Note - You can expose the proxy's port 3001 via ngrok, if your apps are in a VPC/network that you can't run the proxy inside of. 
+If your apps are in a VPC/network that you can't run the proxy inside of, then you can expose the proxy's port 3001 via ngrok
 1. `ngrok http 3001`
 2. put the ngrok address in your app's DSN like:  
 `SENTRY_DSN=https://1f2d7bf845114ba6a5ba19ee07db6800@5b286dac3e72.ngrok.io/3`
@@ -111,23 +111,24 @@ https://crontab.guru/
 `python3 test/db.py 5` gets the 5th event  
 `python3 test/dby.py 5 -b` gets the 5th event and prints its body  
 
+6 events in the am-transactions-sqlite.db was 57kb  
+19 events tracing-example was 92kb
+
 #### gotcha's
 The timestamp from `go run event-to-sentry.go` is sometimes earlier than today's date and time 
+
 Use python3 or else else `getvalue()` in `python/event-to-sentry.py` returns wrong data type
 
 #### other
-Borrowed code from: getsentry/sentry-python, getsentry/sentry-go, goreplay, getsentry/gor-middleware
+Borrowed code from: getsentry/sentry-python, getsentry/sentry-go, getsentry/gor-middleware, goreplay
 
 https://develop.sentry.dev/sdk/store for info on the Sentry store endpoint
 
-https://develop.sentry.dev/sdk/event-payloads/ for what a sdk event looks like. Here's [/img/example-payload.png](./img/example-payload.png) from javascript
+https://develop.sentry.dev/sdk/event-payloads/ for what a sdk event looks like. Here's an [example-payload.png](./img/example-payload.png) from javascript
 
-6 events in the am-transactions-sqlite.db was 57kb
-19 events tracing-example was 92kb
+Tested on ubuntu 18.04 LTS, go 1.12.9 linux/amd64, sentry-sdk 0.14.2, flask Python 3.6.9
 
-tested on: ubuntu 18.04 LTS, go 1.12.9 linux/amd64, sentry-sdk 0.14.2, flask Python 3.6.9
-
-`python-dotenv` vs `dotenv`
+`python-dotenv` vs `dotenv` if os.getenv is failing
 
 ## Todo
 - Mobile android errors/crashes/sessions

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -181,7 +181,7 @@ func init() {
 	projectDSNs["python_celery"] = parseDSN(os.Getenv("DSN_PYTHON_CELERY"))
 
 	fmt.Println("> db flag", *db)
-	if *id == "" {
+	if *db == "" {
 		database, _ = sql.Open("sqlite3", os.Getenv("SQLITE"))
 	} else {
 		database, _ = sql.Open("sqlite3", *db)

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -127,6 +127,8 @@ func matchDSN(projectDSNs map[string]*DSN, event Event) string {
 	platform := event.platform
 	headers := unmarshalJSON(event.headers)
 
+	// TODO if db is tracing-example-multiproject.db, then how to route to 3 different python projects. have to know from 'event' if it was gateway, django or celery somehow.
+	// 'if event_is_from_gateway then projectDSN["gateway"]
 	// only python events have X-Sentry-Auth
 	if headers["X-Sentry-Auth"] != nil {
 		xSentryAuth := headers["X-Sentry-Auth"].(string)
@@ -176,6 +178,8 @@ func init() {
 	projectDSNs["node"] = parseDSN(os.Getenv("DSN_EXPRESS_SAAS"))
 	projectDSNs["go"] = parseDSN(os.Getenv("DSN_GO_SAAS"))
 	projectDSNs["ruby"] = parseDSN(os.Getenv("DSN_RUBY_SAAS"))
+
+	// TODO if event from db was one of these, these will get used, regardless of a --js -py being passed above
 	projectDSNs["python_gateway"] = parseDSN(os.Getenv("DSN_PYTHON_GATEWAY"))
 	projectDSNs["python_django"] = parseDSN(os.Getenv("DSN_PYTHON_DJANGO"))
 	projectDSNs["python_celery"] = parseDSN(os.Getenv("DSN_PYTHON_CELERY"))

--- a/python/event.py
+++ b/python/event.py
@@ -12,8 +12,10 @@ https://<key>@<organization>sentry.io/<project>
 https://<key>@localhost:9000/<project>
 
 An original (unmodified) DSN will send event directly to Sentry
-SDK requires that DSN ends in a number. Use zero's for proxy endpoints so no confusion with Project Id's
+SDK requires that DSN ends in a number. Zero's didn't work.
 # SENTRY_SELF_HOSTED = 'localhost:9000'
+
+Could do 'python event.py -s for "save" or -f for "forward" or -sf for "save_and_forward"
 """
 
 # send event to Sentry or the Flask proxy which interfaces with Sqlite
@@ -21,11 +23,9 @@ DSN = os.getenv('DSN_PYTHONTEST')
 KEY = DSN.split('@')[0]
 PROXY = 'localhost:3001'
 
-# FORWARD, SAVE, SAVE_AND_FORWARD = '/00', '/01', '/02' if using cli, like 'python event.py -s for "save" or -f for "forward" or -sf for "save_and_forward"
 
 # proxy forwards the event on to Sentry. Doesn't save to DB
 MODIFIED_DSN_FORWARD = KEY + '@' + PROXY + '/2'
-# print('MODIFIED_DSN_FORWARD', MODIFIED_DSN_FORWARD)
 
 # proxy saves the event to database. Doesn't send to Senry.
 MODIFIED_DSN_SAVE = KEY + '@' + PROXY + '/3'
@@ -42,7 +42,7 @@ def stacktrace():
 def app():
     # stacktrace()
     
-    # Exception literals will not have stack traces
+    # Exception literals do not have stack traces
     sentry_sdk.capture_exception(Exception("Five0Ten"))
 
 def dsn_and_proxy_check():
@@ -66,13 +66,3 @@ if __name__ == '__main__':
     dsn_and_proxy_check()
     initialize_sentry()
     app()
-
-
-# I didn't like this
-# def dsn(string):
-#     return KEY + '@'+ PROXY + string
-# MODIFIED_DSN_FORWARD = dsn('/00')
-# MODIFIED_DSN_SAVE = dsn('/01')
-# MODIFIED_DSN_SAVE_AND_FORWARD = dsn('/02')
-
-# Ideally, should decide from cli which, like 'python event.py -s' or '-f' or '-sf'

--- a/python/proxy.py
+++ b/python/proxy.py
@@ -4,8 +4,6 @@ from dotenv import load_dotenv
 from flask import Flask, request, json, abort
 from flask_cors import CORS
 import json
-# import sentry_sdk
-# from sentry_sdk.integrations.flask import FlaskIntegration
 from services import compress_gzip, decompress_gzip, get_event_type
 import sqlite3
 import string # ?
@@ -15,7 +13,6 @@ load_dotenv()
 http = urllib3.PoolManager()
 
 app = Flask(__name__)
-# app.run(ssl_context='adhoc') # flask run --cert=adhoc
 
 app.run(threaded=True)
 CORS(app)

--- a/python/proxy.py
+++ b/python/proxy.py
@@ -68,8 +68,7 @@ with sqlite3.connect(database) as db:
 def forward():
     print('> FORWARD')
 
-    # TODO https://github.com/thinkocapo/undertaker/issues/48
-    # TODO exception.platform may have been available, as well as exception.sdk
+    # TODO exception.platform may have been available, as well as exception.sdk https://github.com/thinkocapo/undertaker/issues/48
     def make(headers):
         request_headers = {}
         user_agent = request.headers.get('User-Agent').lower()

--- a/python/proxy.py
+++ b/python/proxy.py
@@ -29,9 +29,12 @@ print("""
 
 SENTRY=''
 
-# Must pass auth key in URL (not request headers) or else 403 CSRF error from Sentry
-# AM Transactions can't be sent to any self-hosted Sentry instance as of 05/30/2020 
-# https://github.com/getsentry/sentry/releases
+
+""" This is only for using the proxy to forward events directly to Sentry and NOT save them in your database
+If you're not using this, you can ignore it
+Must pass auth key in URL (not request headers) or else 403 CSRF error from Sentry
+AM Transactions can't be sent to any self-hosted Sentry instance as of 10.0.0 05/30/2020 
+"""
 def sentryUrl(DSN):
     if ("@localhost:" in DSN):
         KEY = DSN.split('@')[0][7:]
@@ -44,9 +47,6 @@ def sentryUrl(DSN):
         HOST = DSN.split('@')[1].split('/')[0]
         PROJECT_ID = DSN.split('@')[1].split('/')[1] 
         return "https://%s/api/%s/store/?sentry_key=%s&sentry_version=7" % (HOST, PROJECT_ID, KEY)
-        # MODIFIED_DSN_FORWARD used a dsn of "http://0d52d5f4e8a64f5ab2edce50d88a7626@o87286.ingest.sentry.io/1428657" in thinkocapo/react to call:
-        # return "https://o87286.ingest.sentry.io/api/1428657/store/?sentry_key=0d52d5f4e8a64f5ab2edce50d88a7626&sentry_version=7" # will-frontend-react in SAAS
-        # it ^ reached SaaS sentry.io
 
 SQLITE = os.getenv('SQLITE')
 database = SQLITE or os.getcwd() + "/sqlite.db"

--- a/python/services.py
+++ b/python/services.py
@@ -21,7 +21,6 @@ def compress_gzip(dict_body):
     try:
         body = io.BytesIO()
         with gzip.GzipFile(fileobj=body, mode="w") as f:
-            # print('dict_body', dict_body) loks good
             f.write(json.dumps(dict_body, allow_nan=False).encode("utf-8"))
     except Exception as e:
         raise e


### PR DESCRIPTION
## Done
--js and --py flags
--db flag

readme modernized

1 executable. its behavior now depends on the --db you pass it, and DSN's
```
./bin/event-to-sentry --all --db=am-transactions-timeout-sqlite.db --js=https://7a53554e9cdc490094f9564104e4fc9e@o87286.ingest.sentry.io/5178842 --py=https://2ba68720d38e42079b243c9c5774e05c@o87286.ingest.sentry.io/1316515

./bin/event-to-sentry --all --db=tracing-example-multiproject.db

```