### PR TITLE
Refactor files for Decoders Transformers

### DIFF
--- a/decoders.go
+++ b/decoders.go
@@ -1,11 +1,7 @@
 package main
 
 import (
-	// "bytes"
-	// "compress/gzip"
-	// "encoding/json"
 	"fmt"
-	// "io/ioutil"
 	"strings"
 )
 
@@ -16,7 +12,6 @@ func decodeEnvelope(event Event) (string, Timestamper, EnvelopeEncoder, string) 
 	PYTHON := event.Platform == "python"
 
 	storeEndpoint := matchDSN(projectDSNs, event)
-
 	fmt.Printf("> storeEndpoint %v \n", storeEndpoint)
 
 	envelope := event.Body

--- a/decoders.go
+++ b/decoders.go
@@ -40,7 +40,7 @@ func decodeEnvelope(event Event) (string, Timestamper, EnvelopeEncoder, []string
 	case JAVASCRIPT && TRANSACTION:
 		return envelope, updateTimestamps, envelopeEncoder, jsHeaders, storeEndpoint
 	case PYTHON && TRANSACTION:
-		return envelope, updateTimestamps, envelopeEncoder, pyHeaders, storeEndpoint // because envelope so jsEncoder....?
+		return envelope, updateTimestamps, envelopeEncoderPy, pyHeaders, storeEndpoint // because envelope so jsEncoder....?
 	}
 
 	return envelope, updateTimestamps, envelopeEncoder, jsHeaders, storeEndpoint

--- a/decoders.go
+++ b/decoders.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	// "bytes"
+	// "compress/gzip"
+	// "encoding/json"
+	"fmt"
+	// "io/ioutil"
+	"strings"
+)
+
+func decodeEnvelope(event Event) (string, Timestamper, EnvelopeEncoder, []string, string) {
+
+	TRANSACTION := event.Kind == "transaction"
+	JAVASCRIPT := event.Platform == "javascript"
+	PYTHON := event.Platform == "python"
+	jsHeaders := []string{"Accept-Encoding", "Content-Length", "Content-Type", "User-Agent"}
+	pyHeaders := []string{"Accept-Encoding", "Content-Length", "Content-Encoding", "Content-Type", "User-Agent"}
+	storeEndpoint := matchDSN(projectDSNs, event)
+
+	fmt.Printf("> storeEndpoint %v \n", storeEndpoint)
+
+	envelope := event.Body
+
+	items := strings.Split(envelope, "\n")
+	fmt.Println("\n > # of items in envelope", len(items))
+	for idx, _ := range items {
+		fmt.Println("> item", idx)
+		// TODO need do this for every item in items
+		// var item map[string]interface{}
+		// if err := json.Unmarshal([]byte(items[0]), &item); err != nil {
+			// panic(err)
+		// }
+	}
+
+	// TODO return envelope array-of-map[string]interfaces{} back to a string
+	// TODO return bodyEncoder for []byte(envelope) maybe called 'envelopeEncoder'. Go strings are already utf-8 encoded
+	
+	switch {
+	case JAVASCRIPT && TRANSACTION:
+		return envelope, updateTimestamps, envelopeEncoder, jsHeaders, storeEndpoint
+	case PYTHON && TRANSACTION:
+		return envelope, updateTimestamps, envelopeEncoder, pyHeaders, storeEndpoint // because envelope so jsEncoder....?
+	}
+
+	return envelope, updateTimestamps, envelopeEncoder, jsHeaders, storeEndpoint
+}
+
+// TODO remove 'TRANSACTION' from here
+func decodeEvent(event Event) (map[string]interface{}, Timestamper, BodyEncoder, []string, string) {
+
+	body := unmarshalJSON([]byte(event.Body))
+
+	JAVASCRIPT := event.Platform == "javascript"
+	PYTHON := event.Platform == "python"
+	ANDROID := event.Platform == "android"
+
+	ERROR := event.Kind == "error"
+	TRANSACTION := event.Kind == "transaction"
+
+	jsHeaders := []string{"Accept-Encoding", "Content-Length", "Content-Type", "User-Agent"}
+	pyHeaders := []string{"Accept-Encoding", "Content-Length", "Content-Encoding", "Content-Type", "User-Agent"}
+	androidHeaders := []string{"Content-Length","User-Agent","Connection","Content-Encoding","X-Forwarded-Proto","Host","Accept","X-Forwarded-For"} // X-Sentry-Auth omitted
+	storeEndpoint := matchDSN(projectDSNs, event)
+	fmt.Printf("> storeEndpoint %v \n", storeEndpoint)
+
+	switch {
+	case ANDROID && TRANSACTION:
+		return body, updateTimestamp, pyEncoder, androidHeaders, storeEndpoint
+	case ANDROID && ERROR:
+		return body, updateTimestamp, pyEncoder, androidHeaders, storeEndpoint
+
+	case JAVASCRIPT && TRANSACTION:
+		return body, updateTimestamps, jsEncoder, jsHeaders, storeEndpoint
+	case JAVASCRIPT && ERROR:
+		return body, updateTimestamp, jsEncoder, jsHeaders, storeEndpoint
+
+	case PYTHON && TRANSACTION:
+		return body, updateTimestamps, pyEncoder, pyHeaders, storeEndpoint
+	case PYTHON && ERROR:
+		return body, updateTimestamp, pyEncoder, pyHeaders, storeEndpoint
+	}
+
+	return body, updateTimestamps, jsEncoder, jsHeaders, storeEndpoint
+}

--- a/decoders.go
+++ b/decoders.go
@@ -9,13 +9,13 @@ import (
 	"strings"
 )
 
-func decodeEnvelope(event Event) (string, Timestamper, EnvelopeEncoder, []string, string) {
+func decodeEnvelope(event Event) (string, Timestamper, EnvelopeEncoder, string) {
 
 	TRANSACTION := event.Kind == "transaction"
 	JAVASCRIPT := event.Platform == "javascript"
 	PYTHON := event.Platform == "python"
-	jsHeaders := []string{"Accept-Encoding", "Content-Length", "Content-Type", "User-Agent"}
-	pyHeaders := []string{"Accept-Encoding", "Content-Length", "Content-Encoding", "Content-Type", "User-Agent"}
+	// jsHeaders := []string{"Accept-Encoding", "Content-Length", "Content-Type", "User-Agent"}
+	// pyHeaders := []string{"Accept-Encoding", "Content-Length", "Content-Encoding", "Content-Type", "User-Agent"}
 	storeEndpoint := matchDSN(projectDSNs, event)
 
 	fmt.Printf("> storeEndpoint %v \n", storeEndpoint)
@@ -38,16 +38,16 @@ func decodeEnvelope(event Event) (string, Timestamper, EnvelopeEncoder, []string
 	
 	switch {
 	case JAVASCRIPT && TRANSACTION:
-		return envelope, updateTimestamps, envelopeEncoder, jsHeaders, storeEndpoint
+		return envelope, updateTimestamps, envelopeEncoder, storeEndpoint
 	case PYTHON && TRANSACTION:
-		return envelope, updateTimestamps, envelopeEncoderPy, pyHeaders, storeEndpoint // because envelope so jsEncoder....?
+		return envelope, updateTimestamps, envelopeEncoderPy, storeEndpoint // because envelope so jsEncoder....?
 	}
 
-	return envelope, updateTimestamps, envelopeEncoder, jsHeaders, storeEndpoint
+	return envelope, updateTimestamps, envelopeEncoder, storeEndpoint
 }
 
 // TODO remove 'TRANSACTION' from here
-func decodeEvent(event Event) (map[string]interface{}, Timestamper, BodyEncoder, []string, string) {
+func decodeError(event Event) (map[string]interface{}, Timestamper, BodyEncoder, string) {
 
 	body := unmarshalJSON([]byte(event.Body))
 
@@ -58,28 +58,28 @@ func decodeEvent(event Event) (map[string]interface{}, Timestamper, BodyEncoder,
 	ERROR := event.Kind == "error"
 	TRANSACTION := event.Kind == "transaction"
 
-	jsHeaders := []string{"Accept-Encoding", "Content-Length", "Content-Type", "User-Agent"}
-	pyHeaders := []string{"Accept-Encoding", "Content-Length", "Content-Encoding", "Content-Type", "User-Agent"}
-	androidHeaders := []string{"Content-Length","User-Agent","Connection","Content-Encoding","X-Forwarded-Proto","Host","Accept","X-Forwarded-For"} // X-Sentry-Auth omitted
+	//jsHeaders := []string{"Accept-Encoding", "Content-Length", "Content-Type", "User-Agent"}
+	//pyHeaders := []string{"Accept-Encoding", "Content-Length", "Content-Encoding", "Content-Type", "User-Agent"}
+	//androidHeaders := []string{"Content-Length","User-Agent","Connection","Content-Encoding","X-Forwarded-Proto","Host","Accept","X-Forwarded-For"} // X-Sentry-Auth omitted
 	storeEndpoint := matchDSN(projectDSNs, event)
 	fmt.Printf("> storeEndpoint %v \n", storeEndpoint)
 
 	switch {
 	case ANDROID && TRANSACTION:
-		return body, updateTimestamp, pyEncoder, androidHeaders, storeEndpoint
+		return body, updateTimestamp, pyEncoder, storeEndpoint
 	case ANDROID && ERROR:
-		return body, updateTimestamp, pyEncoder, androidHeaders, storeEndpoint
+		return body, updateTimestamp, pyEncoder, storeEndpoint
 
 	case JAVASCRIPT && TRANSACTION:
-		return body, updateTimestamps, jsEncoder, jsHeaders, storeEndpoint
+		return body, updateTimestamps, jsEncoder, storeEndpoint
 	case JAVASCRIPT && ERROR:
-		return body, updateTimestamp, jsEncoder, jsHeaders, storeEndpoint
+		return body, updateTimestamp, jsEncoder, storeEndpoint
 
 	case PYTHON && TRANSACTION:
-		return body, updateTimestamps, pyEncoder, pyHeaders, storeEndpoint
+		return body, updateTimestamps, pyEncoder, storeEndpoint
 	case PYTHON && ERROR:
-		return body, updateTimestamp, pyEncoder, pyHeaders, storeEndpoint
+		return body, updateTimestamp, pyEncoder, storeEndpoint
 	}
 
-	return body, updateTimestamps, jsEncoder, jsHeaders, storeEndpoint
+	return body, updateTimestamps, jsEncoder, storeEndpoint
 }

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -118,40 +118,9 @@ func (e Event) String() string {
 	return fmt.Sprintf("\n Event { Platform: %s, Type: %s }\n", e.Platform, e.Kind) // index somehow?
 }
 
-// func envelopeEncoder(envelope string) []byte {
-// 	return []byte(envelope)
-// }
-// func envelopeEncoderPy(envelope string) []byte {
-// 	buf := encodeGzip([]byte(envelope))
-// 	return buf.Bytes()
-// }
-// func jsEncoder(body map[string]interface{}) []byte {
-// 	return marshalJSON(body)
-// }
-// func pyEncoder(body map[string]interface{}) []byte {
-// 	bodyBytes := marshalJSON(body)
-// 	buf := encodeGzip(bodyBytes)
-// 	return buf.Bytes()
-// }
-
-// type BodyEncoder func(map[string]interface{}) []byte
-// type EnvelopeEncoder func(string) []byte
-// type Timestamper func(map[string]interface{}, string) map[string]interface{}
 
 func matchDSN(projectDSNs map[string]*DSN, event Event) string {
 	
-	// for getsentry/tracing-example (a situation where you have 3 Python Projects)
-	// headers := event.Headers
-	// if headers["X-Sentry-Auth"] != "" {
-	// 	xSentryAuth := headers["X-Sentry-Auth"]
-	// 	for _, projectDSN := range projectDSNs {
-	// 		if strings.Contains(xSentryAuth, projectDSN.key) {
-	// 			fmt.Println("> match", projectDSN)
-	// 			return projectDSN.storeEndpoint()
-	// 		}
-	// 	}
-	// }
-
 	platform := event.Platform
 
 	var storeEndpoint string
@@ -237,7 +206,6 @@ func main() {
 		var timestamper Timestamper 
 		var bodyEncoder BodyEncoder
 		var envelopeEncoder EnvelopeEncoder
-		// var headerKeys []string
 		var storeEndpoint string
 		var requestBody []byte
 
@@ -248,7 +216,6 @@ func main() {
 			body = release(body)
 			body = user(body)
 			body = timestamper(body, event.Platform)
-			
 			undertake(body)
 			requestBody = bodyEncoder(body)
 
@@ -270,12 +237,10 @@ func main() {
 			if requestErr != nil {
 				log.Fatal(requestErr)
 			}
-
 			responseData, responseDataErr := ioutil.ReadAll(response.Body)
 			if responseDataErr != nil {
 				log.Fatal(responseDataErr)
 			}
-
 			fmt.Printf("\n> EVENT KIND: %s | RESPONSE: %s\n", event.Kind, string(responseData))
 		} else {
 			fmt.Printf("\n> %s event IGNORED", event.Kind)

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -123,6 +123,10 @@ func (e Event) String() string {
 func envelopeEncoder(envelope string) []byte {
 	return []byte(envelope)
 }
+func envelopeEncoderPy(envelope string) []byte {
+	buf := encodeGzip([]byte(envelope))
+	return buf.Bytes()
+}
 func jsEncoder(body map[string]interface{}) []byte {
 	return marshalJSON(body)
 }
@@ -256,8 +260,9 @@ func main() {
 
 			// TODO transform the envelope Array, update traceId, release, user, timestamps
 			// undertaker()			
-			requestBody = []byte(envelope)
-			// requestBody = envelopeEncoder(envelope)
+			// requestBody = []byte(envelope)
+
+			requestBody = envelopeEncoder(envelope)
 		}
 
 		request := buildRequest(requestBody, event.Headers, storeEndpoint)
@@ -295,7 +300,13 @@ func buildRequest(requestBody []byte, eventHeaders map[string]string, storeEndpo
 	}
 
 	for key, value := range eventHeaders {
-		request.Header.Set(key, value)
+		// request.Header.Set(key, value)
+		fmt.Println("HEADER", key, value)
+		if (key == "X-Sentry-Auth") {
+			fmt.Println("ignore")
+		} else {
+			request.Header.Set(key, value)
+		}
 	}
 	return request
 }

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -7,11 +7,9 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 	"io/ioutil"
 	"log"
-	"math/rand"
 	"net/http"
 	"net/url"
 	"os"
-	"github.com/google/uuid"
 	"github.com/joho/godotenv"
 	"strings"
 	"time"
@@ -239,29 +237,29 @@ func main() {
 		var timestamper Timestamper 
 		var bodyEncoder BodyEncoder
 		var envelopeEncoder EnvelopeEncoder
-		var headerKeys []string
-		fmt.Println(headerKeys)
+		// var headerKeys []string
 		var storeEndpoint string
 		var requestBody []byte
 
 		if (event.Kind == "error") {			
-			body, timestamper, bodyEncoder, headerKeys, storeEndpoint = decodeEvent(event)
+			
+			body, timestamper, bodyEncoder, storeEndpoint = decodeError(event)
 			body = eventId(body)
 			body = release(body)
 			body = user(body)
 			body = timestamper(body, event.Platform)
+			
 			undertake(body)
 			requestBody = bodyEncoder(body)
+
 		} else if (event.Kind == "transaction") {
 			
-			envelope, timestamper, envelopeEncoder, headerKeys, storeEndpoint = decodeEnvelope(event)
-
-			fmt.Printf(" %T %T %T %T\n", timestamper, envelopeEncoder, headerKeys, storeEndpoint)
+			envelope, timestamper, envelopeEncoder, storeEndpoint = decodeEnvelope(event)
+			// fmt.Printf(" %T %T %T %T\n", timestamper, envelopeEncoder, storeEndpoint)
 
 			// TODO transform the envelope Array, update traceId, release, user, timestamps
+			
 			// undertaker()			
-			// requestBody = []byte(envelope)
-
 			requestBody = envelopeEncoder(envelope)
 		}
 
@@ -294,75 +292,26 @@ func main() {
 }
 
 func buildRequest(requestBody []byte, eventHeaders map[string]string, storeEndpoint string) *http.Request {
+	if requestBody == nil {
+		log.Fatalln("buildRequest missing requestBody")
+	}
+	if eventHeaders == nil {
+		log.Fatalln("buildRequest missing eventHeaders")
+	}
+	if storeEndpoint == "" {
+		log.Fatalln("buildRequest missing storeEndpoint")
+	}
+
 	request, errNewRequest := http.NewRequest("POST", storeEndpoint, bytes.NewReader(requestBody)) // &buf
 	if errNewRequest != nil {
 		log.Fatalln(errNewRequest)
 	}
 
 	for key, value := range eventHeaders {
-		// request.Header.Set(key, value)
-		fmt.Println("HEADER", key, value)
-		if (key == "X-Sentry-Auth") {
-			fmt.Println("ignore")
-		} else {
+		if (key != "X-Sentry-Auth") {
 			request.Header.Set(key, value)
 		}
 	}
 	return request
 }
 
-// same eventId cannot be accepted twice by Sentry
-func eventId(body map[string]interface{}) map[string]interface{} {
-	if _, ok := body["event_id"]; !ok {
-		log.Print("no event_id on object from DB")
-	}
-	var uuid4 = strings.ReplaceAll(uuid.New().String(), "-", "")
-	body["event_id"] = uuid4
-	fmt.Println("> event_id updated", body["event_id"])
-	return body
-}
-
-// CalVer-lite
-func release(body map[string]interface{}) map[string]interface{} {
-	date := time.Now()
-	month := date.Month()
-	day := date.Day()
-	var week int
-	switch {
-	case day <= 7:
-		week = 1
-	case day >= 8 && day <= 14:
-		week = 2
-	case day >= 15 && day <= 21:
-		week = 3
-	case day >= 22:
-		week = 4
-	}
-	release := fmt.Sprint(int(month), ".", week)
-	body["release"] = release
-	fmt.Println("> release", body["release"])
-	return body
-}
-
-func user(body map[string]interface{}) map[string]interface{} {
-	if body["user"] == nil {
-		body["user"] = make(map[string]interface{})
-		user := body["user"].(map[string]interface{})
-		rand.Seed(time.Now().UnixNano())
-		alpha := strings.Split("abcdefghijklmnopqrstuvwxyz", "")[rand.Intn(9)]
-		var alphanumeric string
-		for i := 0; i < 3; i++ {
-			alphanumeric += strings.Split("abcdefghijklmnopqrstuvwxyz0123456789", "")[rand.Intn(35)]
-		}
-		user["email"] = fmt.Sprint(alpha, alphanumeric, "@yahoo.com")
-	}
-	return body
-}
-
-func undertake(body map[string]interface{}) {
-	if body["tags"] == nil {
-		body["tags"] = make(map[string]interface{})
-	}
-	tags := body["tags"].(map[string]interface{})
-	tags["undertaker"] = "h4ckweek"
-}

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -118,25 +118,25 @@ func (e Event) String() string {
 	return fmt.Sprintf("\n Event { Platform: %s, Type: %s }\n", e.Platform, e.Kind) // index somehow?
 }
 
-func envelopeEncoder(envelope string) []byte {
-	return []byte(envelope)
-}
-func envelopeEncoderPy(envelope string) []byte {
-	buf := encodeGzip([]byte(envelope))
-	return buf.Bytes()
-}
-func jsEncoder(body map[string]interface{}) []byte {
-	return marshalJSON(body)
-}
-func pyEncoder(body map[string]interface{}) []byte {
-	bodyBytes := marshalJSON(body)
-	buf := encodeGzip(bodyBytes)
-	return buf.Bytes()
-}
+// func envelopeEncoder(envelope string) []byte {
+// 	return []byte(envelope)
+// }
+// func envelopeEncoderPy(envelope string) []byte {
+// 	buf := encodeGzip([]byte(envelope))
+// 	return buf.Bytes()
+// }
+// func jsEncoder(body map[string]interface{}) []byte {
+// 	return marshalJSON(body)
+// }
+// func pyEncoder(body map[string]interface{}) []byte {
+// 	bodyBytes := marshalJSON(body)
+// 	buf := encodeGzip(bodyBytes)
+// 	return buf.Bytes()
+// }
 
-type BodyEncoder func(map[string]interface{}) []byte
-type EnvelopeEncoder func(string) []byte
-type Timestamper func(map[string]interface{}, string) map[string]interface{}
+// type BodyEncoder func(map[string]interface{}) []byte
+// type EnvelopeEncoder func(string) []byte
+// type Timestamper func(map[string]interface{}, string) map[string]interface{}
 
 func matchDSN(projectDSNs map[string]*DSN, event Event) string {
 	

--- a/python/proxy.py
+++ b/python/proxy.py
@@ -135,13 +135,14 @@ def save():
         print('> JAVASCRIPT ', event_type)
         for key in ['Accept-Encoding','Content-Length','Content-Type','User-Agent']:
             request_headers[key] = request.headers.get(key)
-        body = request.data
+        body = request.data.decode("utf-8")
 
     event = {
         'platform': event_platform,
         'kind': event_type,
         'headers': request_headers,
-        'body': request.data.decode("utf-8")
+        'body': body
+        # 'body': request.data.decode("utf-8") #TODO should be body.decode("utf-8")?
     }
 
     try:

--- a/transformers.go
+++ b/transformers.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"fmt"
+	_ "github.com/mattn/go-sqlite3"
+	"log"
+	"math/rand"
+	"github.com/google/uuid"
+	"strings"
+	"time"
+)
+
+// same eventId cannot be accepted twice by Sentry
+func eventId(body map[string]interface{}) map[string]interface{} {
+	if _, ok := body["event_id"]; !ok {
+		log.Print("no event_id on object from DB")
+	}
+	var uuid4 = strings.ReplaceAll(uuid.New().String(), "-", "")
+	body["event_id"] = uuid4
+	fmt.Println("> event_id updated", body["event_id"])
+	return body
+}
+
+// CalVer-lite
+func release(body map[string]interface{}) map[string]interface{} {
+	date := time.Now()
+	month := date.Month()
+	day := date.Day()
+	var week int
+	switch {
+	case day <= 7:
+		week = 1
+	case day >= 8 && day <= 14:
+		week = 2
+	case day >= 15 && day <= 21:
+		week = 3
+	case day >= 22:
+		week = 4
+	}
+	release := fmt.Sprint(int(month), ".", week)
+	body["release"] = release
+	fmt.Println("> release", body["release"])
+	return body
+}
+
+func user(body map[string]interface{}) map[string]interface{} {
+	if body["user"] == nil {
+		body["user"] = make(map[string]interface{})
+		user := body["user"].(map[string]interface{})
+		rand.Seed(time.Now().UnixNano())
+		alpha := strings.Split("abcdefghijklmnopqrstuvwxyz", "")[rand.Intn(9)]
+		var alphanumeric string
+		for i := 0; i < 3; i++ {
+			alphanumeric += strings.Split("abcdefghijklmnopqrstuvwxyz0123456789", "")[rand.Intn(35)]
+		}
+		user["email"] = fmt.Sprint(alpha, alphanumeric, "@yahoo.com")
+	}
+	return body
+}
+
+func undertake(body map[string]interface{}) {
+	if body["tags"] == nil {
+		body["tags"] = make(map[string]interface{})
+	}
+	tags := body["tags"].(map[string]interface{})
+	tags["undertaker"] = "h4ckweek"
+}

--- a/utils.go
+++ b/utils.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"strings"
 )
 
 func decodeGzip(bodyBytesInput []byte) (bodyBytesOutput []byte) {
@@ -28,43 +27,6 @@ func encodeGzip(b []byte) bytes.Buffer {
 	w.Close()
 	// return buf.Bytes()
 	return buf
-}
-
-func decodeEnvelope(event Event) (string, Timestamper, BodyEncoder, []string, string) {
-
-	TRANSACTION := event.Kind == "transaction"
-	JAVASCRIPT := event.Platform == "javascript"
-	PYTHON := event.Platform == "python"
-	jsHeaders := []string{"Accept-Encoding", "Content-Length", "Content-Type", "User-Agent"}
-	pyHeaders := []string{"Accept-Encoding", "Content-Length", "Content-Encoding", "Content-Type", "User-Agent"}
-	storeEndpoint := matchDSN(projectDSNs, event)
-
-	fmt.Printf("> storeEndpoint %v \n", storeEndpoint)
-
-	envelope := event.Body
-
-	items := strings.Split(envelope, "\n")
-	fmt.Println("\n > # of items in envelope", len(items))
-	for idx, _ := range items {
-		fmt.Println("\n > item is...", idx)
-		// TODO need do this for every item in items
-		// var item map[string]interface{}
-		// if err := json.Unmarshal([]byte(items[0]), &item); err != nil {
-			// panic(err)
-		// }
-	}
-
-	// TODO return envelope array-of-map[string]interfaces{} back to a string
-	// TODO return bodyEncoder for []byte(envelope) maybe called 'envelopeEncoder'. Go strings are already utf-8 encoded
-	
-	switch {
-	case JAVASCRIPT && TRANSACTION:
-		return envelope, updateTimestamps, jsEncoder, jsHeaders, storeEndpoint
-	case PYTHON && TRANSACTION:
-		return envelope, updateTimestamps, jsEncoder, pyHeaders, storeEndpoint // because envelope so jsEncoder....?
-	}
-
-	return envelope, updateTimestamps, jsEncoder, jsHeaders, storeEndpoint
 }
 
 func unmarshalJSON(bytes []byte) map[string]interface{} {


### PR DESCRIPTION
Will be easier to work on the repo now.

## Done
decodeError and decodeEnvelope in decoders.go. Encoder functions taken out of event-to-sentry and put into decoders.go

transformers in their own file

bodyEncoder and envelopeEncoder now too

tested both errors+transactions in both.json successfully.

check storeEndpoint envelopeEndpoint URL in buildRequest and rename it to sentryUrl or similar.

## Next
transforming each item in Envelope

rename storeEndpoint to sentryUrl because represents Store and Envelope

dsn.go and maybe event.go, check sentry-go sdk.