### PR TITLE
Unmarshal Envelope Byte String to Go Maps and Back To Envelope Byte String

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,10 +196,7 @@ Google Cloud SDK 303.0.0
 initialize your file.json to an empty array [] because it gets appended to
 
 ## Todo
-08/30 Python Tx erroring in event-to-sentry in its envelope
-- isolate a python transaction, keep triming it. object wasn't ending after the 'email'?
-- python transactions have a final '\n' that's causing panic: unexpected end of JSON input. javascripts don't have this
-- in proxy, check and eliminate the '\n'? remove it from _item in Go!
+08/30 Python items in array of items...?
 UNDERTAKER transaction envelope (go) Timestamps and event/Trace Id's  
 UNDERTAKER ordering of Spans, sessions/transactions linked appropriately  
 

--- a/README.md
+++ b/README.md
@@ -197,11 +197,27 @@ initialize your file.json to an empty array [] because it gets appended to
 
 ## Todo
 08/30 Python items in array of items...?
-1. WORKS rm length attribute from all 7 or 8 transactions in old_both.json (if errors, then re-record using new Tx stuff I updated today in sentry-demos/tracing.git)
+DONE test that can rm length attribute from all 8 transactions in old_both.json, and send to Sentry
+DONE remove 'length' attribute from the item map
+DONE re-record a data set with PR data npm-sentry-tracing
 
-2. remove 'length' attribute from the interface. (put it back in both_eight.json first. only did 4 of them?)
-3. re-record a data set with merged PR data??
-4. re-test
+
+1. update eventId's on Transactions so can replay them.
+eventId is in first envelope item as well as largest envelope item, for both JS + PY transactions.  
+per item but inside 1 envelope, generate new event_id and put on both envelope items here.
+
+optionally turn the item interface{} into a Item struct, just ot make sure has everything needed.
+
+2. traceId - is in largest envelope item, for both JS + PY transactions
+keep a map of map[id's]itemPointersArray 2. at end, iterate through this map and give each item in itemPointersArray the same new generated Id
+
+notes...
+1. ^ update each itemInterface in place...?
+2. 'OR' return envelope array-of-map[string]interfaces{} back to a string. then update
+3. ^ update each itemInterface in place...and put to some kind of 'output' envelope
+
+
+
 
 5.
 UNDERTAKER transaction envelope (go) Timestamps and event/Trace Id's  
@@ -215,3 +231,5 @@ Envelopes + Sessions for Mobile
 cloud:  
 move `context.Background()` to `func init()`  
 ./go.mod and ./api/go.mod  
+
+interfaces

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ initialize your file.json to an empty array [] because it gets appended to
 
 ## Todo
 08/30 Python items in array of items...?
+
 UNDERTAKER transaction envelope (go) Timestamps and event/Trace Id's  
 UNDERTAKER ordering of Spans, sessions/transactions linked appropriately  
 

--- a/README.md
+++ b/README.md
@@ -196,15 +196,17 @@ Google Cloud SDK 303.0.0
 initialize your file.json to an empty array [] because it gets appended to
 
 ## Todo
-proxy save  
-event-to-sentry  
+08/30 Python Tx erroring in event-to-sentry in its envelope
+- isolate a python transaction, keep triming it. object wasn't ending after the 'email'?
+- python transactions have a final '\n' that's causing panic: unexpected end of JSON input. javascripts don't have this
+- in proxy, check and eliminate the '\n'? remove it from _item in Go!
+UNDERTAKER transaction envelope (go) Timestamps and event/Trace Id's  
+UNDERTAKER ordering of Spans, sessions/transactions linked appropriately  
 
-getsentry/tracing-example.json (3 DSN's python) again. logic based on name.json for which DSN keys. refactor.  
 
-bulk creation (cronjob) from JSON again
+bulk creation (cronjob) from JSON again  
 
-Envelopes (choose Mobile Health or JS/Python which means upgrade to modern SDK)  
-
+Envelopes + Sessions for Mobile  
 
 -H id for selecting 1 vs -H all for selecting all  
 move `context.Background()` to `func init()`  

--- a/README.md
+++ b/README.md
@@ -197,15 +197,18 @@ initialize your file.json to an empty array [] because it gets appended to
 
 ## Todo
 08/30 Python items in array of items...?
+0. run both.json 1 tx again
+1. rm length attribute from all 7 or 8 transactions in old_both.json (if errors, then re-record using new Tx stuff I updated today in sentry-demos/tracing.git)
 
 UNDERTAKER transaction envelope (go) Timestamps and event/Trace Id's  
 UNDERTAKER ordering of Spans, sessions/transactions linked appropriately  
 
 
-bulk creation (cronjob) from JSON again  
+#### future
+Cronjob for 5,000/hr (3.6million for 30 days)
 
 Envelopes + Sessions for Mobile  
 
--H id for selecting 1 vs -H all for selecting all  
+cloud:  
 move `context.Background()` to `func init()`  
 ./go.mod and ./api/go.mod  

--- a/README.md
+++ b/README.md
@@ -197,12 +197,15 @@ initialize your file.json to an empty array [] because it gets appended to
 
 ## Todo
 08/30 Python items in array of items...?
-0. run both.json 1 tx again
-1. rm length attribute from all 7 or 8 transactions in old_both.json (if errors, then re-record using new Tx stuff I updated today in sentry-demos/tracing.git)
+1. WORKS rm length attribute from all 7 or 8 transactions in old_both.json (if errors, then re-record using new Tx stuff I updated today in sentry-demos/tracing.git)
 
+2. remove 'length' attribute from the interface. (put it back in both_eight.json first. only did 4 of them?)
+3. re-record a data set with merged PR data??
+4. re-test
+
+5.
 UNDERTAKER transaction envelope (go) Timestamps and event/Trace Id's  
 UNDERTAKER ordering of Spans, sessions/transactions linked appropriately  
-
 
 #### future
 Cronjob for 5,000/hr (3.6million for 30 days)

--- a/README.md
+++ b/README.md
@@ -196,32 +196,25 @@ Google Cloud SDK 303.0.0
 initialize your file.json to an empty array [] because it gets appended to
 
 ## Todo
-08/30 Python items in array of items...?
 DONE test that can rm length attribute from all 8 transactions in old_both.json, and send to Sentry
 DONE remove 'length' attribute from the item map
 DONE re-record a data set with PR data npm-sentry-tracing
-
 
 1. update eventId's on Transactions so can replay them.
 eventId is in first envelope item as well as largest envelope item, for both JS + PY transactions.  
 per item but inside 1 envelope, generate new event_id and put on both envelope items here.
 
-optionally turn the item interface{} into a Item struct, just ot make sure has everything needed.
+2. update Timestamps - on transaction envelopes
 
-2. traceId - is in largest envelope item, for both JS + PY transactions
-keep a map of map[id's]itemPointersArray 2. at end, iterate through this map and give each item in itemPointersArray the same new generated Id
+3. update TraceId's - on transaction envelopes
+traceId - is in largest envelope item, for both JS + PY transactions
+keep a map of map[id's]itemPointersArray 2. at end, iterate through this map and update each item in itemPointersArray by reference, with a new generated Id
 
-notes...
-1. ^ update each itemInterface in place...?
-2. 'OR' return envelope array-of-map[string]interfaces{} back to a string. then update
-3. ^ update each itemInterface in place...and put to some kind of 'output' envelope
-
-
-
-
-5.
-UNDERTAKER transaction envelope (go) Timestamps and event/Trace Id's  
-UNDERTAKER ordering of Spans, sessions/transactions linked appropriately  
+Notes:  
+optionally turn the item interface{} into a Item struct, just ot make sure has everything needed.  
+update each itemInterface in place...?  
+update each itemInterface in place...and put to some kind of 'output' envelope  
+double-check ordering of Spans, sessions/transactions linked appropriately  
 
 #### future
 Cronjob for 5,000/hr (3.6million for 30 days)

--- a/decoders.go
+++ b/decoders.go
@@ -32,10 +32,27 @@ func decodeEnvelope(event Event) (string, Timestamper, EnvelopeEncoder, string) 
 		if err := json.Unmarshal([]byte(item), &itemInterface); err != nil {
 			panic(err)
 		}
-		fmt.Println("\n ITEM ===================================", itemInterface)
+		fmt.Println("\n ITEM", item)
 	}
 
-	// TODO return envelope array-of-map[string]interfaces{} back to a string
+	// I
+	// GOAL
+	// print/long ALL transaction types in both.json again
+
+	// GOAL update all Timestamps and SEND
+
+	// II
+	// GOAL
+	// eventId - is in first envelope item as well as largest envelope item, for both JS + PY transactions
+	// 1. per item but inside 1 envelope, generate new event_id and put on both envelope items here....EASY
+
+	// traceId - is in largest envelope item, for both JS + PY transactions
+	// 1. keep a map of map[id's]itemPointersArray 2. at end, iterate through this map and give each item in itemPointersArray the same new generated Id
+
+	// notes...
+	// 1. ^ update each itemInterface in place...?
+	// 2. 'OR' return envelope array-of-map[string]interfaces{} back to a string. then update
+	// 3. ^ update each itemInterface in place...and put to some kind of 'output' envelope
 	
 	switch {
 	case JAVASCRIPT && TRANSACTION:

--- a/decoders.go
+++ b/decoders.go
@@ -76,6 +76,8 @@ func decodeEnvelope(event Event) ([]interface{}, Timestamper, EnvelopeEncoder, s
 			fmt.Println("\n > no timestamp, must be a header")
 		}
 
+		// TODO 6:55p remove length off of 'parsed' here, or a transformer must do it!
+
 		// TODO return interface{}, and do Item{} type later, or never!
 		items = append(items, parsed)
 		// items = append(items, item1)

--- a/decoders.go
+++ b/decoders.go
@@ -6,8 +6,9 @@ import (
 	"reflect"
 	"strings"
 )
-// []interface{}
-func decodeEnvelope(event Event) ([]Item, Timestamper, EnvelopeEncoder, string) {
+
+// func decodeEnvelope(event Event) ([]Item, Timestamper, EnvelopeEncoder, string) {
+func decodeEnvelope(event Event) ([]interface{}, Timestamper, EnvelopeEncoder, string) {
 
 	TRANSACTION := event.Kind == "transaction"
 	JAVASCRIPT := event.Platform == "javascript"
@@ -26,7 +27,8 @@ func decodeEnvelope(event Event) ([]Item, Timestamper, EnvelopeEncoder, string) 
 	}
 	fmt.Println("\n > # of envelopeItems in envelope", len(envelopeItems))
 
-	items := []Item{}
+	// items := []Item{}
+	var items  []interface{}
 
 	for idx, item := range envelopeItems {
 		fmt.Printf("\n> item.string %v %T \n", idx, item) // string
@@ -37,7 +39,7 @@ func decodeEnvelope(event Event) ([]Item, Timestamper, EnvelopeEncoder, string) 
 			// if ever 9 numbers in a row
 			// then it's Item2{}
 
-		item1 := Item{}
+		// item1 := Item{}
 		// item2 := Item2{}
 
 		// if err := json.Unmarshal([]byte(item), &item1); err != nil {
@@ -54,9 +56,9 @@ func decodeEnvelope(event Event) ([]Item, Timestamper, EnvelopeEncoder, string) 
 		if err := json.Unmarshal([]byte(item), &parsed); err != nil {
 			panic(err)
 		}
-		fmt.Println("parsed.platform", parsed["platform"])
+		// fmt.Println("parsed.platform", parsed["platform"])
 
-		fmt.Println("PARSED", parsed)
+		// fmt.Println("PARSED", parsed)
 
 		if val, ok := parsed["timestamp"]; ok {
 			fmt.Println("\n > parsed[timestamp]", val)
@@ -74,7 +76,9 @@ func decodeEnvelope(event Event) ([]Item, Timestamper, EnvelopeEncoder, string) 
 			fmt.Println("\n > no timestamp, must be a header")
 		}
 
-		items = append(items, item1)
+		// TODO return interface{}, and do Item{} type later, or never!
+		items = append(items, parsed)
+		// items = append(items, item1)
 	}
 	fmt.Println("\n # of items in []Item{}", len(items))
 

--- a/encoders.go
+++ b/encoders.go
@@ -10,7 +10,8 @@ import (
 // func envelopeEncoder(envelope string) []byte {
 // 	return []byte(envelope)
 // }
-func envelopeEncoderJs(items []Item) []byte {
+// func envelopeEncoderJs(items []Item) []byte {
+func envelopeEncoderJs(items []interface{}) []byte {
 	output := []byte{}
 	for _, item := range items {
 		// fmt.Println("\n > envelopeEncoder", item)
@@ -22,7 +23,8 @@ func envelopeEncoderJs(items []Item) []byte {
 	return output
 	// if err := json.Unmarshal([]byte(item), &item1); err != nil {
 }
-func envelopeEncoderPy(items []Item) []byte {
+// func envelopeEncoderPy(items []Item) []byte {
+func envelopeEncoderPy(items []interface{}) []byte {
 	output := ""
 	for idx, item := range items {
 		byteString, _ := json.Marshal(item)
@@ -62,4 +64,5 @@ func pyEncoder(body map[string]interface{}) []byte {
 
 type BodyEncoder func(map[string]interface{}) []byte
 // type EnvelopeEncoder func(string) []byte OG
-type EnvelopeEncoder func(items []Item) []byte
+// type EnvelopeEncoder func(items []Item) []byte
+type EnvelopeEncoder func(items []interface{}) []byte

--- a/encoders.go
+++ b/encoders.go
@@ -1,37 +1,26 @@
 package main
 
 import (
-	"fmt"
+	// "fmt"
 	"encoding/json"
-	"strings"
+	// "strings"
 )
 
-// Encoders OG
-// func envelopeEncoder(envelope string) []byte {
-// 	return []byte(envelope)
-// }
-// func envelopeEncoderJs(items []Item) []byte {
 func envelopeEncoderJs(items []interface{}) []byte {
 	output := []byte{}
 	for _, item := range items {
-		// fmt.Println("\n > envelopeEncoder", item)
 		output = append(output, marshalJSONItem(item)...)
 		newLine := []byte("\n")
 		output = append(output, newLine...)
 	}
-	// fmt.Println("\n > OUTPUT ", output)
 	return output
-	// if err := json.Unmarshal([]byte(item), &item1); err != nil {
 }
-// func envelopeEncoderPy(items []Item) []byte {
+
 func envelopeEncoderPy(items []interface{}) []byte {
 	output := ""
-	for idx, item := range items {
+	for _, item := range items {
 		byteString, _ := json.Marshal(item)
-		fmt.Println("\n > envelopeEncoder idx", idx)
-
 		output = output + string(byteString) + "\n" // `\n` \r
-
 		// if (len(items)-1 != idx) {
 		// 	output = output + string(byteString) + "\n" // `\n` \r
 		// } else {
@@ -39,19 +28,12 @@ func envelopeEncoderPy(items []interface{}) []byte {
 		// 	output = output + string(byteString)
 		// }
 	}
-	// fmt.Println("\n > envelopeEncoder OUTPUT", output)
-	splitted := strings.Split(output, "\n")
-	fmt.Println("\n > envelopeEncoderPy splitted length", len(splitted))
+	// splitted := strings.Split(output, "\n")
+	// fmt.Println("\n > envelopeEncoderPy splitted length", len(splitted))
 
 	buf := encodeGzip([]byte(output))
 	return buf.Bytes()
 }
-// OG
-// func envelopeEncoderPy(envelope string) []byte {
-// 	buf := encodeGzip([]byte(envelope))
-// 	return buf.Bytes()
-// }
-
 
 func jsEncoder(body map[string]interface{}) []byte {
 	return marshalJSON(body)
@@ -63,6 +45,4 @@ func pyEncoder(body map[string]interface{}) []byte {
 }
 
 type BodyEncoder func(map[string]interface{}) []byte
-// type EnvelopeEncoder func(string) []byte OG
-// type EnvelopeEncoder func(items []Item) []byte
 type EnvelopeEncoder func(items []interface{}) []byte

--- a/encoders.go
+++ b/encoders.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"fmt"
+	"encoding/json"
+	"strings"
+)
+
+// Encoders OG
+// func envelopeEncoder(envelope string) []byte {
+// 	return []byte(envelope)
+// }
+func envelopeEncoderJs(items []Item) []byte {
+	output := []byte{}
+	for _, item := range items {
+		// fmt.Println("\n > envelopeEncoder", item)
+		output = append(output, marshalJSONItem(item)...)
+		newLine := []byte("\n")
+		output = append(output, newLine...)
+	}
+	fmt.Println("\n > OUTPUT ", output)
+	return output
+	// if err := json.Unmarshal([]byte(item), &item1); err != nil {
+}
+func envelopeEncoderPy(items []Item) []byte {
+	output := ""
+	for idx, item := range items {
+		byteString, _ := json.Marshal(item)
+		fmt.Println("\n > envelopeEncoder idx", idx)
+
+		output = output + string(byteString) + "\n" // `\n` \r
+
+		// if (len(items)-1 != idx) {
+		// 	output = output + string(byteString) + "\n" // `\n` \r
+		// } else {
+		// 	fmt.Println("\n > FINAL")
+		// 	output = output + string(byteString)
+		// }
+	}
+	fmt.Println("\n > envelopeEncoder OUTPUT", output)
+	splitted := strings.Split(output, "\n")
+	fmt.Println("\n > splitted length", len(splitted))
+
+	buf := encodeGzip([]byte(output))
+	return buf.Bytes()
+}
+// OG
+// func envelopeEncoderPy(envelope string) []byte {
+// 	buf := encodeGzip([]byte(envelope))
+// 	return buf.Bytes()
+// }
+
+
+func jsEncoder(body map[string]interface{}) []byte {
+	return marshalJSON(body)
+}
+func pyEncoder(body map[string]interface{}) []byte {
+	bodyBytes := marshalJSON(body)
+	buf := encodeGzip(bodyBytes)
+	return buf.Bytes()
+}
+
+type BodyEncoder func(map[string]interface{}) []byte
+// type EnvelopeEncoder func(string) []byte OG
+type EnvelopeEncoder func(items []Item) []byte

--- a/encoders.go
+++ b/encoders.go
@@ -18,7 +18,7 @@ func envelopeEncoderJs(items []Item) []byte {
 		newLine := []byte("\n")
 		output = append(output, newLine...)
 	}
-	fmt.Println("\n > OUTPUT ", output)
+	// fmt.Println("\n > OUTPUT ", output)
 	return output
 	// if err := json.Unmarshal([]byte(item), &item1); err != nil {
 }
@@ -37,9 +37,9 @@ func envelopeEncoderPy(items []Item) []byte {
 		// 	output = output + string(byteString)
 		// }
 	}
-	fmt.Println("\n > envelopeEncoder OUTPUT", output)
+	// fmt.Println("\n > envelopeEncoder OUTPUT", output)
 	splitted := strings.Split(output, "\n")
-	fmt.Println("\n > splitted length", len(splitted))
+	fmt.Println("\n > envelopeEncoderPy splitted length", len(splitted))
 
 	buf := encodeGzip([]byte(output))
 	return buf.Bytes()

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -147,7 +147,9 @@ func matchDSN(projectDSNs map[string]*DSN, event Event) string {
 }
 
 type Envelope struct {
-	items []Item
+	// TODO items {}interface
+	items []interface{}
+	// items []Item
 }
 
 type Item struct {
@@ -253,7 +255,8 @@ func main() {
 		var envelopeEncoder EnvelopeEncoder
 		var storeEndpoint string
 		var requestBody []byte
-		var items []Item
+		// var items []Item
+		var items []interface{}
 		if (event.Kind == "error") {			
 			
 			body, timestamper, bodyEncoder, storeEndpoint = decodeError(event)
@@ -267,7 +270,6 @@ func main() {
 		} else if (event.Kind == "transaction") {
 			
 			items, timestamper, envelopeEncoder, storeEndpoint = decodeEnvelope(event)
-
 			// transformations...
 			// envelope = timestamper(envelope)
 			// envelope = eventIds(envelope)

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -147,7 +147,7 @@ func matchDSN(projectDSNs map[string]*DSN, event Event) string {
 }
 
 type Envelope struct {
-	// TODO items {}interface
+	// TODO items {}interface'
 	items []interface{}
 	// items []Item
 }
@@ -275,6 +275,8 @@ func main() {
 			// envelope = eventIds(envelope)
 			// update the traceIdS
 			// update release, user
+
+			items = removeLengthField(items)
 			
 			// undertaker()			
 			requestBody = envelopeEncoder(items)

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -173,6 +173,31 @@ type Item struct {
 	User map[string]interface{} `json:"user,omitempty"`
 }
 
+type Item2 struct {
+	Event_id string `json:"event_id,omitempty"`
+	Sent_at string `json:"sent_at,omitempty"`
+
+	Length int `json:"length,omitempty"`
+	Type string `json:"type,omitempty"`
+	Content_type string `json:"content_type,omitempty"`
+
+	Start_timestamp float64 `json:"start_timestamp,omitempty"`
+	Transaction string `json:"transaction,omitempty"`
+	Server_name string `json:"server_name,omitempty"`
+	Tags map[string]interface{} `json:"tags,omitempty"`
+	Contexts map[string]interface{} `json:"contexts,omitempty"`
+	Timestamp float64 `json:"timestamp,omitempty"`
+	Extra map[string]interface{} `json:"extra,omitempty"`
+	Request map[string]interface{} `json:"request,omitempty"`
+	Environment string `json:"environment,omitempty"`
+	Platform string `json:"platform,omitempty"`
+	// Todo spans []
+	Sdk map[string]interface{} `json:"sdk,omitempty"`
+	User map[string]interface{} `json:"user,omitempty"`
+}
+
+// TODO need an ItemFinal that has unified timestamp?
+
 func init() {
 	if err := godotenv.Load(); err != nil {
 		log.Print("No .env file found")

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -146,11 +146,9 @@ func matchDSN(projectDSNs map[string]*DSN, event Event) string {
 	return storeEndpoint
 }
 
-type Envelope struct {
-	// TODO items {}interface'
-	items []interface{}
-	// items []Item
-}
+// type Envelope struct {
+// 	items []interface{}
+// }
 
 type Item struct {
 	Event_id string `json:"event_id,omitempty"`
@@ -248,38 +246,38 @@ func main() {
 	for idx, event := range events {
 		fmt.Printf("> EVENT# %v \n", idx)
 
-		var body map[string]interface{}
-		// var envelope string
+		var bodyError map[string]interface{}
+		var envelopeItems []interface{}
+
 		var timestamper Timestamper 
 		var bodyEncoder BodyEncoder
 		var envelopeEncoder EnvelopeEncoder
 		var storeEndpoint string
 		var requestBody []byte
-		// var items []Item
-		var items []interface{}
+
 		if (event.Kind == "error") {			
 			
-			body, timestamper, bodyEncoder, storeEndpoint = decodeError(event)
-			body = eventId(body)
-			body = release(body)
-			body = user(body)
-			body = timestamper(body, event.Platform)
-			undertake(body)
-			requestBody = bodyEncoder(body)
+			bodyError, timestamper, bodyEncoder, storeEndpoint = decodeError(event)
+			bodyError = eventId(bodyError)
+			bodyError = release(bodyError)
+			bodyError = user(bodyError)
+			bodyError = timestamper(bodyError, event.Platform)
+			undertake(bodyError)
+			requestBody = bodyEncoder(bodyError)
 
 		} else if (event.Kind == "transaction") {
 			
-			items, timestamper, envelopeEncoder, storeEndpoint = decodeEnvelope(event)
-			// transformations...
+			envelopeItems, timestamper, envelopeEncoder, storeEndpoint = decodeEnvelope(event)
 			// envelope = timestamper(envelope)
 			// envelope = eventIds(envelope)
 			// update the traceIdS
 			// update release, user
 
-			items = removeLengthField(items)
+			envelopeItems = removeLengthField(envelopeItems)
 			
+			// TODO
 			// undertaker()			
-			requestBody = envelopeEncoder(items)
+			requestBody = envelopeEncoder(envelopeItems)
 		}
 
 		request := buildRequest(requestBody, event.Headers, storeEndpoint)
@@ -295,7 +293,7 @@ func main() {
 			}
 			fmt.Printf("\n> EVENT KIND: %s | RESPONSE: %s\n", event.Kind, string(responseData))
 		} else {
-			fmt.Printf("\n> %s event IGNORED", event.Kind)
+			fmt.Printf("> %s event IGNORED", event.Kind)
 		}
 
 		// TODO - break early, or auto-select 1 before the for loop

--- a/transformers.go
+++ b/transformers.go
@@ -65,3 +65,11 @@ func undertake(body map[string]interface{}) {
 	tags := body["tags"].(map[string]interface{})
 	tags["undertaker"] = "h4ckweek"
 }
+
+// Python Transactions have "length"
+func removeLengthField(items []interface{}) []interface{} {
+	for _, item := range items {
+		delete(item.(map[string]interface{}), "length")
+	}
+	return items
+}

--- a/transformers.go
+++ b/transformers.go
@@ -66,7 +66,7 @@ func undertake(body map[string]interface{}) {
 	tags["undertaker"] = "h4ckweek"
 }
 
-// Python Transactions have "length"
+// Python Transactions have "length". Remove it or else rejected.
 func removeLengthField(items []interface{}) []interface{} {
 	for _, item := range items {
 		delete(item.(map[string]interface{}), "length")

--- a/utils.go
+++ b/utils.go
@@ -37,7 +37,8 @@ func marshalJSON(body map[string]interface{}) []byte {
 	return bodyBytes
 }
 
-func marshalJSONItem(item Item) []byte {
+// func marshalJSONItem(item Item) []byte {
+func marshalJSONItem(item interface{}) []byte {
 	//fmt.Println("\n > marshalJSONItem BEFORE", item) // {2b7e81ebe33349cda2a77f04c30e8174 2020-08-29T05:43:31.286573Z}
 	itemBytes, errItemBytes := json.Marshal(item)
 	if errItemBytes != nil {

--- a/utils.go
+++ b/utils.go
@@ -37,7 +37,6 @@ func marshalJSON(body map[string]interface{}) []byte {
 	return bodyBytes
 }
 
-// func marshalJSONItem(item Item) []byte {
 func marshalJSONItem(item interface{}) []byte {
 	//fmt.Println("\n > marshalJSONItem BEFORE", item) // {2b7e81ebe33349cda2a77f04c30e8174 2020-08-29T05:43:31.286573Z}
 	itemBytes, errItemBytes := json.Marshal(item)

--- a/utils.go
+++ b/utils.go
@@ -29,6 +29,24 @@ func encodeGzip(b []byte) bytes.Buffer {
 	return buf
 }
 
+func marshalJSON(body map[string]interface{}) []byte {
+	bodyBytes, errBodyBytes := json.Marshal(body)
+	if errBodyBytes != nil {
+		fmt.Println(errBodyBytes)
+	}
+	return bodyBytes
+}
+
+func marshalJSONItem(item Item) []byte {
+	//fmt.Println("\n > marshalJSONItem BEFORE", item) // {2b7e81ebe33349cda2a77f04c30e8174 2020-08-29T05:43:31.286573Z}
+	itemBytes, errItemBytes := json.Marshal(item)
+	if errItemBytes != nil {
+		fmt.Println(errItemBytes)
+	}
+	//fmt.Println("\n > marshalJSONItem ", string(itemBytes)) // {"event_id":"2b7e81ebe33349cda2a77f04c30e8174","sent_at":"2020-08-29T05:43:31.286573Z"}
+	return itemBytes
+}
+
 func unmarshalJSON(bytes []byte) map[string]interface{} {
 	var _interface map[string]interface{}
 	if err := json.Unmarshal(bytes, &_interface); err != nil {
@@ -37,10 +55,12 @@ func unmarshalJSON(bytes []byte) map[string]interface{} {
 	return _interface
 }
 
-func marshalJSON(body map[string]interface{}) []byte {
-	bodyBytes, errBodyBytes := json.Marshal(body)
-	if errBodyBytes != nil {
-		fmt.Println(errBodyBytes)
-	}
-	return bodyBytes
-}
+// func unmarshalJSONItem(item string) Item {
+// 	var _interface Item
+// 	if err := json.Unmarshal([]byte(item), &_interface); err != nil {
+// 		panic(err)
+// 	}
+// 	return _interface
+// 	// return Item{id: "test"} // wouldn't work
+// }
+


### PR DESCRIPTION
## Done
Remove the ""Length" attribute from envelope items because it fails for Python Transactions. I believe it needs to be updated dynamically for size of the payload/items(?). But, it's the same data I'm sending back, so why would that change? If I print before/after it just shows the keys in different order, but that's a Print....keys aren't Ordered like elements in an array.


fixed empty envelope items from Python Envelopes ending in a trailing \n

decided not to use Item Struct yet, because timestamps are sometimes float64 and sometimes strings. So hard to json.Unmarshal it.

`itemEnvelopes []interface{}`

## Testing
js tx, py tx - Pageload
http://localhost:9000/organizations/sentry/discover/results/?end=2020-09-03T17%3A06%3A54&field=transaction&field=project&field=trace.span&field=transaction.duration&field=timestamp&name=Transactions+with+Trace+ID+11f3930c815747a999c06c75238df4cc&project=-1&query=event.type%3Atransaction+trace%3A11f3930c815747a999c06c75238df4cc&sort=-timestamp&start=2020-09-02T17%3A06%3A51&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1. 
1 of each

js tx, py tx - Checkout
http://localhost:9000/organizations/sentry/discover/results/?end=2020-09-03T17%3A07%3A04&field=transaction&field=project&field=trace.span&field=transaction.duration&field=timestamp&name=Transactions+with+Trace+ID+daed1bbe8ef94fa8b432af320094ac5b&project=-1&query=event.type%3Atransaction+trace%3Adaed1bbe8ef94fa8b432af320094ac5b&sort=-timestamp&start=2020-09-02T17%3A07%3A04&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1
1 of each

py error linked to py tx - Checkout
http://localhost:9000/organizations/sentry/discover/python:a7fc2e5b02614d4d9aee78ad397e5da8/

js error - Checkout
http://localhost:9000/organizations/sentry/discover/javascript:dc05cd6dcccd458cafb699cc2dac73ed/?environment=prod&field=title&field=event.type&field=project&field=user.display&field=timestamp&name=All+Events&query=&sort=-timestamp&statsPeriod=24h&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1

## Next
Update eventId, timestamps, and TraceId's.