### PR TITLE
Trace Ids - View Span

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,10 +205,15 @@ DONE update Timestamps - on transaction envelopes
 3 items in envelope and start_timestamp+timestamp are on the 3rd item of the 3.
 Appears they always have both. Not one without the other.
 DONE Update the Release
-
-Udate TraceId's - on transaction envelopes
+DONE Udate TraceId's - on transaction envelopes
 traceId - is in largest envelope item, for both JS + PY transactions
 keep a map of map[id's]itemPointersArray 2. at end, iterate through this map and update each item in itemPointersArray by reference, with a new generated Id
+
+DONE Update traceId on Errors (should match one of the traceId's after) and now py transaction is linked to py error
+
+/toolstore parent traceId needs to match the spans traceId. the span's never got updated!
+
+Update spanIds? may need this in order for them to link. getSpanIds function maybe
 
 
 Double-Check:

--- a/README.md
+++ b/README.md
@@ -204,22 +204,24 @@ eventId is in envelope's first item as well as largest envelope item, so 2 out o
 DONE update Timestamps - on transaction envelopes
 3 items in envelope and start_timestamp+timestamp are on the 3rd item of the 3.
 Appears they always have both. Not one without the other.
-
-Update the Release
+DONE Update the Release
 
 Udate TraceId's - on transaction envelopes
 traceId - is in largest envelope item, for both JS + PY transactions
 keep a map of map[id's]itemPointersArray 2. at end, iterate through this map and update each item in itemPointersArray by reference, with a new generated Id
 
-Notes:  
-optionally turn the item interface{} into a Item struct, just ot make sure has everything needed.
-double-check ordering of Spans, sessions/transactions linked appropriately  
+
+Double-Check:
+Ordering of Spans, sessions/transactions linked appropriately  
 
 #### future
-shellscript w/ sentry-cli for source maps, w/ Release according to CalVer
+Shellscript w/ sentry-cli for source maps, w/ Release according to CalVer
 Cronjob for 5,000/hr (3.6million for 30 days)
 
+Refactor:  
+optionally turn the item interface{} into a Item struct, and use Timestamp type for start_timestamp/timestamp.
+
 Mobile Envelopes, Sessions
+
 Cloud move `context.Background()` to `func init()`  
 Other ./go.mod and ./api/go.mod  
-Other interfaces

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -30,6 +30,11 @@ var (
 	SENTRY_URL  string
 	exists      bool
 	projectDSNs map[string]*DSN
+	// traceIdMap0 map[string][]*Item
+	traceIdMap map[string][]interface{}
+	
+	// traceIdMap2 map[string][]string
+	// traceIdMap := map[string][]*interface{}
 )
 
 type DSN struct {
@@ -150,7 +155,18 @@ func matchDSN(projectDSNs map[string]*DSN, event Event) string {
 // 	items []interface{}
 // }
 
+// type Item map[string]interface{}
+
+// type Timestamp time.Time
+type Timestamp struct {
+	time.Time
+	rfc3339 bool
+}
+
 type Item struct {
+	Timestamp Timestamp `json:"timestamp,omitempty"`
+	// Timestamp time.Time `json:"timestamp,omitempty"`
+	
 	Event_id string `json:"event_id,omitempty"`
 	Sent_at string `json:"sent_at,omitempty"`
 
@@ -163,7 +179,8 @@ type Item struct {
 	Server_name string `json:"server_name,omitempty"`
 	Tags map[string]interface{} `json:"tags,omitempty"`
 	Contexts map[string]interface{} `json:"contexts,omitempty"`
-	Timestamp string `json:"timestamp,omitempty"`
+	
+
 	Extra map[string]interface{} `json:"extra,omitempty"`
 	Request map[string]interface{} `json:"request,omitempty"`
 	Environment string `json:"environment,omitempty"`
@@ -179,6 +196,8 @@ func init() {
 	if err := godotenv.Load(); err != nil {
 		log.Print("No .env file found")
 	}
+
+	traceIdMap = make(map[string][]interface{})
 
 	all = flag.Bool("all", false, "send all events. default is send latest event")
 	id = flag.String("id", "", "id of event in sqlite database") // 08/27 non-functional today
@@ -271,7 +290,7 @@ func main() {
 			fmt.Printf("> %s event IGNORED \n", event.Kind)
 		}
 
-		// TODO - break early, or auto-select 1 before the for loop
+		// break early, or auto-select 1 before the for loop
 		// if !*all {
 		// 	return
 		// }

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -219,7 +219,6 @@ func main() {
 		panic(err)
 	}
 
-	// TODO rename body as errorBody or eventPayload?
 	for _, event := range events {
 		fmt.Printf("\n> KIND|PLATFORM %v %v ", event.Kind, event.Platform)
 		var bodyError map[string]interface{}
@@ -245,15 +244,19 @@ func main() {
 			envelopeItems = eventIds(envelopeItems)
 			envelopeItems = envelopeTimestamper(envelopeItems, event.Platform)
 			envelopeItems = envelopeReleases(envelopeItems, event.Platform, event.Kind)
-			// update the traceIdS
+			envelopeItems = getEnvelopeTraceIds(envelopeItems)
+
 			// update user if missing
 			envelopeItems = removeLengthField(envelopeItems)
-			// undertaker()			
 			requestBody = envelopeEncoder(envelopeItems)
+			// undertaker()			
 		}
 
-		request := buildRequest(requestBody, event.Headers, storeEndpoint)
+		// 1. Array of Envelopes
+			// encode later, after setting new TraceId
+			// build Request later
 
+		request := buildRequest(requestBody, event.Headers, storeEndpoint)
 		if !*ignore {
 			response, requestErr := httpClient.Do(request)
 			if requestErr != nil {
@@ -275,6 +278,9 @@ func main() {
 
 		time.Sleep(1000 * time.Millisecond)
 	}
+	// 2. Update All Envelopes with proper Trace Id - setEnvelopeTraceIds
+	// 3. Send all to Sentry.io
+		// build all requests, or have that done ahead of time.
 	return
 }
 

--- a/transformers.go
+++ b/transformers.go
@@ -167,24 +167,6 @@ func getEnvelopeTraceIds(items []interface{}) {
 				}
 			}
 		}
-
-		// TMP
-		// contexts := item.(map[string]interface{})["contexts"]
-		// if (contexts != nil) {
-		// trace := contexts.(map[string]interface{})["trace"]
-
-		// 	trace := contexts.(map[string]interface{})["trace"].(map[string]interface{})
-		// 	trace_id := trace["trace_id"].(string)
-		// 	fmt.Println("> trace_id BEFORE1", trace_id)
-		// 	fmt.Println("\n > trace_id", trace_id)
-
-		// 	if trace_id != "" {
-		// 		// timestamp := item.(map[string]interface{})["timestamp"].(string)
-		// 		fmt.Println("\n trace_id ", trace_id)
-		// 		traceIdMap[trace_id] = append(traceIdMap[trace_id], item)
-		// 	}
-		// }
-
 	}
 }
 
@@ -193,20 +175,22 @@ func setEnvelopeTraceIds(requests []Transport) {
 	fmt.Println("\n> setEnvelopeTraceIds <", traceIds)
 
 	for _, TRACE_ID := range traceIds {
-		fmt.Println("\n> current traceIds trace_id |", TRACE_ID)
+		fmt.Println("\n> _ _ _ _ _ _ TRACE_ID _ _ _ _ _ _ _", TRACE_ID)
 
 		var uuid4 = strings.ReplaceAll(uuid.New().String(), "-", "")
 		NEW_TRACE_ID := uuid4
 
-		for _, transport := range requests {
+		for idx, transport := range requests {
+			fmt.Println("\n> * * * * * TRANSPORT * * * * * *", idx, transport.kind, transport.platform)
+
 			if transport.kind == "error" {
 				contexts := transport.bodyError["contexts"]
 				if contexts != nil {
 					trace := contexts.(map[string]interface{})["trace"]
 					if TRACE_ID == trace.(map[string]interface{})["trace_id"] {
-						fmt.Println("\n> MATCHED Error trace_id BEFORE", trace.(map[string]interface{})["trace_id"])
+						// fmt.Println("\n> MATCHED Error trace_id BEFORE", trace.(map[string]interface{})["trace_id"])
 						trace.(map[string]interface{})["trace_id"] = NEW_TRACE_ID
-						fmt.Println("> MATCHED Error trace_id AFTER", transport.bodyError["contexts"].(map[string]interface{})["trace"].(map[string]interface{})["trace_id"].(string))
+						// fmt.Println("> MATCHED Error trace_id AFTER", transport.bodyError["contexts"].(map[string]interface{})["trace"].(map[string]interface{})["trace_id"].(string))
 					}
 				}
 			}
@@ -214,28 +198,22 @@ func setEnvelopeTraceIds(requests []Transport) {
 				for _, item := range transport.envelopeItems {
 					contexts := item.(map[string]interface{})["contexts"]
 					if contexts != nil {
-						// fmt.Println("\n> + + + + + + +  CONTEXTS  + + + + +  ", contexts)
-						// spans := item.(map[string]interface{})["spans"]
-						// fmt.Println("XXXXXXXXXXXXX", spans)
-
 						trace := contexts.(map[string]interface{})["trace"]
 						if TRACE_ID == trace.(map[string]interface{})["trace_id"] {
-							fmt.Println("\n> MATCHED Transaction trace_id BEFORE", trace.(map[string]interface{})["trace_id"])
+							// fmt.Println("\n> MATCHED Transaction trace_id BEFORE", trace.(map[string]interface{})["trace_id"])
 							trace.(map[string]interface{})["trace_id"] = NEW_TRACE_ID
 							fmt.Println("> MATCHED Transaction trace_id AFTER", item.(map[string]interface{})["contexts"].(map[string]interface{})["trace"].(map[string]interface{})["trace_id"].(string))
-						}
-					}
-					if _, found := item.(map[string]interface{})["spans"]; found {
-						fmt.Println("\n 0 0 00 0 0 0 00 0 0 00 0 00 HAS SPANS 0 0 0 0 0 00 000 0 0")
-						spans := item.(map[string]interface{})["spans"]
+							if _, found := item.(map[string]interface{})["spans"]; found {
+								// fmt.Println("\n 0 0 00 0 0 0 00 0 0 00 0 00 HAS SPANS 0 0 0 0 0 00 000 0 0")
+								spans := item.(map[string]interface{})["spans"]
 
-						if len(spans.([]map[string]interface{})) > 0 {
-							for _, value := range spans.([]map[string]interface{}) {
-								fmt.Println("\n> - - - - - - - - UPDATE SPAN ID - - - - - - - - - ")
-								value["trace_id"] = NEW_TRACE_ID
-								// if key == "trace_id" {
-								// 	value = NEW_TRACE_ID
-								// }
+								if len(spans.([]interface{})) > 0 {
+									for _, value := range spans.([]interface{}) {
+										// fmt.Println("\n> BEFORE ", value.(map[string]interface{})["trace_id"])
+										value.(map[string]interface{})["trace_id"] = NEW_TRACE_ID
+										fmt.Println("> SPAN Transaction trace_id AFTER", item.(map[string]interface{})["spans"].([]interface{})[0].(map[string]interface{})["trace_id"])
+									}
+								}
 							}
 						}
 					}
@@ -289,3 +267,24 @@ func setEnvelopeTraceIds(requests []Transport) {
 // span_id = "{:016x}".format(int(span_id, 16))
 
 // item.(map[string]interface{})["contexts"].(map[string]interface{})["trace"].(map[string]interface{})["trace_id"] = NEW_TRACE_ID
+
+// fmt.Println("\n> + + + + + + +  CONTEXTS  + + + + +  ", contexts)
+// spans := item.(map[string]interface{})["spans"]
+// fmt.Println("XXXXXXXXXXXXX", spans)
+
+// TMP
+// contexts := item.(map[string]interface{})["contexts"]
+// if (contexts != nil) {
+// trace := contexts.(map[string]interface{})["trace"]
+
+// 	trace := contexts.(map[string]interface{})["trace"].(map[string]interface{})
+// 	trace_id := trace["trace_id"].(string)
+// 	fmt.Println("> trace_id BEFORE1", trace_id)
+// 	fmt.Println("\n > trace_id", trace_id)
+
+// 	if trace_id != "" {
+// 		// timestamp := item.(map[string]interface{})["timestamp"].(string)
+// 		fmt.Println("\n trace_id ", trace_id)
+// 		traceIdMap[trace_id] = append(traceIdMap[trace_id], item)
+// 	}
+// }

--- a/transformers.go
+++ b/transformers.go
@@ -150,12 +150,25 @@ func getEnvelopeTraceIds(items []interface{}) {
 				if trace_id != "" {
 					// timestamp := item.(map[string]interface{})["timestamp"].(string)
 					traceIdMap[trace_id] = append(traceIdMap[trace_id], item)
+
+					matched := false
+					for _, value := range traceIds {
+
+						if trace_id == value {
+							fmt.Println("\n X X X X X X X XX amtch X X X X X ")
+							matched = true
+						}
+					}
+
+					if !matched {
+						traceIds = append(traceIds, trace_id)
+					}
 					// fmt.Println("\n VICTOR trace_id ", trace_id)
 				}
 			}
 		}
 
-		// MP
+		// TMP
 		// contexts := item.(map[string]interface{})["contexts"]
 		// if (contexts != nil) {
 		// trace := contexts.(map[string]interface{})["trace"]
@@ -176,33 +189,74 @@ func getEnvelopeTraceIds(items []interface{}) {
 }
 
 // Runs after all transactions (envelopes) have been iterated through.
-func setEnvelopeTraceIds() {
-	// compiles but not needed
-	// for _, item := range traceIdMap[trace_id] {
+func setEnvelopeTraceIds(requests []Transport) {
+	fmt.Println("\n> setEnvelopeTraceIds <", traceIds)
 
-	// self.trace_id = trace_id or uuid.uuid4().hex
-	// self.span_id = span_id or uuid.uuid4().hex[16:]
+	for _, currentTrace_id := range traceIds {
+		fmt.Println("\n> current traceIds trace_id |", currentTrace_id)
 
-	// if trace_id is not None:
-	// trace_id = "{:032x}".format(int(trace_id, 16))
-	// if span_id is not None:
-	// span_id = "{:016x}".format(int(span_id, 16))
-
-	for currentTrace_id, items := range traceIdMap {
 		var uuid4 = strings.ReplaceAll(uuid.New().String(), "-", "")
 		newTraceId := uuid4
 
-		fmt.Println("\n> setEnvelopeTraceIds trace_id", currentTrace_id)
-		for _, item := range items {
-			// contexts := item.(map[string]interface{})
-			contexts := item.(map[string]interface{})["contexts"]
-			trace := contexts.(map[string]interface{})["trace"]
-			// trace := contexts.(map[string]interface{})["trace"]
+		for _, transport := range requests {
+			if transport.kind == "transaction" {
+				for _, item := range transport.envelopeItems {
+					contexts := item.(map[string]interface{})["contexts"]
+					if contexts != nil {
+						trace := contexts.(map[string]interface{})["trace"]
+						if currentTrace_id == trace.(map[string]interface{})["trace_id"] {
+							fmt.Println("\n> MATCHED trace_id BEFORE", trace.(map[string]interface{})["trace_id"])
 
-			// fmt.Println("> trace_id BEFORE2", trace_id)
-			trace.(map[string]interface{})["trace_id"] = newTraceId
-			fmt.Println("> trace_id AFTER", item.(map[string]interface{})["contexts"].(map[string]interface{})["trace"])
-			// fmt.Println("> trace_id AFTER", item.(map[string]interface{})["context"].(map[string]interface{})["trace"].(map[string]interface{}))
+							trace.(map[string]interface{})["trace_id"] = newTraceId
+							// item.(map[string]interface{})["contexts"].(map[string]interface{})["trace"].(map[string]interface{})["trace_id"] = newTraceId
+							fmt.Println("> MATCHED trace_id AFTER", item.(map[string]interface{})["contexts"].(map[string]interface{})["trace"].(map[string]interface{})["trace_id"].(string))
+						}
+					}
+				}
+			}
+			// TODO ERRORS
+			// if transport.kind == "error" {
+			// fmt.Println("Do nothing. it was an error")
+			// }
 		}
+
 	}
+
+	// for _, transport := range requests {
+	// 	// for currentTrace_id, _ := range traceIdMap {
+	// 	for _, currentTrace_id := range traceIds {
+	// 		var uuid4 = strings.ReplaceAll(uuid.New().String(), "-", "")
+	// 		newTraceId := uuid4
+	// 		fmt.Println("\n> current traceIds trace_id |", currentTrace_id)
+
+	// 		// ERRORS
+	// 		if transport.kind == "error" {
+	// 			fmt.Println("Do nothing. it was an error")
+	// 		}
+	// 		if transport.kind == "transaction" {
+	// 			for _, item := range transport.envelopeItems {
+	// 				contexts := item.(map[string]interface{})["contexts"]
+	// 				if contexts != nil {
+	// 					trace := contexts.(map[string]interface{})["trace"]
+	// 					if currentTrace_id == trace.(map[string]interface{})["trace_id"] {
+	// 						fmt.Println("\n> MATCHED trace_id BEFORE", trace.(map[string]interface{})["trace_id"])
+
+	// 						// trace.(map[string]interface{})["trace_id"] = newTraceId
+	// 						item.(map[string]interface{})["contexts"].(map[string]interface{})["trace"].(map[string]interface{})["trace_id"] = newTraceId
+	// 						fmt.Println("> MATCHED trace_id AFTER", item.(map[string]interface{})["contexts"].(map[string]interface{})["trace"].(map[string]interface{})["trace_id"].(string))
+	// 					}
+	// 				}
+	// 			}
+	// 		}
+	// 	}
+	// }
 }
+
+// compiles but not needed
+// for _, item := range traceIdMap[trace_id] {
+// self.trace_id = trace_id or uuid.uuid4().hex
+// self.span_id = span_id or uuid.uuid4().hex[16:]
+// if trace_id is not None:
+// trace_id = "{:032x}".format(int(trace_id, 16))
+// if span_id is not None:
+// span_id = "{:016x}".format(int(span_id, 16))

--- a/transformers.go
+++ b/transformers.go
@@ -32,7 +32,6 @@ func eventIds(envelopeItems []interface{}) []interface{} {
 	return envelopeItems
 }
 
-// item.context.trace.release for js
 func envelopeReleases(envelopeItems []interface{}, platform string, kind string) []interface{} {
 	for _, item := range envelopeItems {
 
@@ -132,4 +131,25 @@ func removeLengthField(items []interface{}) []interface{} {
 		delete(item.(map[string]interface{}), "length")
 	}
 	return items
+}
+
+// TODO could put this to decodeEnvelope? and return it to event-to-sentry. or reference this func from there
+func getEnvelopeTraceIds(items []interface{}) []interface{}{
+	//item.context.trace.traceId
+	for _, item := range items {
+		context := item.(map[string]interface{})
+		trace := context["trace"].(map[string]interface{})
+		trace_id := trace["trace_id"]
+		fmt.Println("\n > trace_id", trace_id)
+		if (trace_id != nil) {
+			//TODO set it in the in-memory store of trace_id's, because a completely different envelope may have the same
+			// { "<trace_id": pointer_to_Item }
+		}
+	}
+	return items
+}
+
+// Runs after all transactions (envelopes) have been iterated through.
+func setEnvelopeTraceIds(items []interface{}) {
+
 }

--- a/transformers.go
+++ b/transformers.go
@@ -139,11 +139,13 @@ func getEnvelopeTraceIds(items []interface{}) []interface{}{
 	for _, item := range items {
 		context := item.(map[string]interface{})
 		trace := context["trace"].(map[string]interface{})
-		trace_id := trace["trace_id"]
+		trace_id := trace["trace_id"].(string)
 		fmt.Println("\n > trace_id", trace_id)
-		if (trace_id != nil) {
-			//TODO set it in the in-memory store of trace_id's, because a completely different envelope may have the same
-			// { "<trace_id": pointer_to_Item }
+
+		if (trace_id != "") {
+			// timestamp := item.(map[string]interface{})["timestamp"].(string)
+			fmt.Println("\n trace_id ", trace_id)
+			traceIdMap[trace_id] = append(traceIdMap[trace_id], item)
 		}
 	}
 	return items
@@ -151,5 +153,17 @@ func getEnvelopeTraceIds(items []interface{}) []interface{}{
 
 // Runs after all transactions (envelopes) have been iterated through.
 func setEnvelopeTraceIds(items []interface{}) {
+	// compiles but not needed
+	// for _, item := range traceIdMap[trace_id] {
 
+	newTraceId := "1973824kjsdf"
+
+	for trace_id, items := range traceIdMap {
+		fmt.Println("> setEnvelopeTraceIds trace_id", trace_id)
+		for _, item := range items {
+			context := item.(map[string]interface{})
+			trace := context["trace"].(map[string]interface{})
+			trace["trace_id"] = newTraceId
+		}
+	}
 }

--- a/transformers.go
+++ b/transformers.go
@@ -155,7 +155,7 @@ func getEnvelopeTraceIds(items []interface{}) {
 					for _, value := range traceIds {
 
 						if trace_id == value {
-							fmt.Println("\n X X X X X X X XX amtch X X X X X ")
+							// fmt.Println("\n X X X X X X X XX amtch X X X X X ")
 							matched = true
 						}
 					}
@@ -192,24 +192,51 @@ func getEnvelopeTraceIds(items []interface{}) {
 func setEnvelopeTraceIds(requests []Transport) {
 	fmt.Println("\n> setEnvelopeTraceIds <", traceIds)
 
-	for _, currentTrace_id := range traceIds {
-		fmt.Println("\n> current traceIds trace_id |", currentTrace_id)
+	for _, TRACE_ID := range traceIds {
+		fmt.Println("\n> current traceIds trace_id |", TRACE_ID)
 
 		var uuid4 = strings.ReplaceAll(uuid.New().String(), "-", "")
-		newTraceId := uuid4
+		NEW_TRACE_ID := uuid4
 
 		for _, transport := range requests {
+			if transport.kind == "error" {
+				contexts := transport.bodyError["contexts"]
+				if contexts != nil {
+					trace := contexts.(map[string]interface{})["trace"]
+					if TRACE_ID == trace.(map[string]interface{})["trace_id"] {
+						fmt.Println("\n> MATCHED Error trace_id BEFORE", trace.(map[string]interface{})["trace_id"])
+						trace.(map[string]interface{})["trace_id"] = NEW_TRACE_ID
+						fmt.Println("> MATCHED Error trace_id AFTER", transport.bodyError["contexts"].(map[string]interface{})["trace"].(map[string]interface{})["trace_id"].(string))
+					}
+				}
+			}
 			if transport.kind == "transaction" {
 				for _, item := range transport.envelopeItems {
 					contexts := item.(map[string]interface{})["contexts"]
 					if contexts != nil {
-						trace := contexts.(map[string]interface{})["trace"]
-						if currentTrace_id == trace.(map[string]interface{})["trace_id"] {
-							fmt.Println("\n> MATCHED trace_id BEFORE", trace.(map[string]interface{})["trace_id"])
+						// fmt.Println("\n> + + + + + + +  CONTEXTS  + + + + +  ", contexts)
+						// spans := item.(map[string]interface{})["spans"]
+						// fmt.Println("XXXXXXXXXXXXX", spans)
 
-							trace.(map[string]interface{})["trace_id"] = newTraceId
-							// item.(map[string]interface{})["contexts"].(map[string]interface{})["trace"].(map[string]interface{})["trace_id"] = newTraceId
-							fmt.Println("> MATCHED trace_id AFTER", item.(map[string]interface{})["contexts"].(map[string]interface{})["trace"].(map[string]interface{})["trace_id"].(string))
+						trace := contexts.(map[string]interface{})["trace"]
+						if TRACE_ID == trace.(map[string]interface{})["trace_id"] {
+							fmt.Println("\n> MATCHED Transaction trace_id BEFORE", trace.(map[string]interface{})["trace_id"])
+							trace.(map[string]interface{})["trace_id"] = NEW_TRACE_ID
+							fmt.Println("> MATCHED Transaction trace_id AFTER", item.(map[string]interface{})["contexts"].(map[string]interface{})["trace"].(map[string]interface{})["trace_id"].(string))
+						}
+					}
+					if _, found := item.(map[string]interface{})["spans"]; found {
+						fmt.Println("\n 0 0 00 0 0 0 00 0 0 00 0 00 HAS SPANS 0 0 0 0 0 00 000 0 0")
+						spans := item.(map[string]interface{})["spans"]
+
+						if len(spans.([]map[string]interface{})) > 0 {
+							for _, value := range spans.([]map[string]interface{}) {
+								fmt.Println("\n> - - - - - - - - UPDATE SPAN ID - - - - - - - - - ")
+								value["trace_id"] = NEW_TRACE_ID
+								// if key == "trace_id" {
+								// 	value = NEW_TRACE_ID
+								// }
+							}
 						}
 					}
 				}
@@ -223,11 +250,11 @@ func setEnvelopeTraceIds(requests []Transport) {
 	}
 
 	// for _, transport := range requests {
-	// 	// for currentTrace_id, _ := range traceIdMap {
-	// 	for _, currentTrace_id := range traceIds {
+	// 	// for TRACE_ID, _ := range traceIdMap {
+	// 	for _, TRACE_ID := range traceIds {
 	// 		var uuid4 = strings.ReplaceAll(uuid.New().String(), "-", "")
-	// 		newTraceId := uuid4
-	// 		fmt.Println("\n> current traceIds trace_id |", currentTrace_id)
+	// 		NEW_TRACE_ID := uuid4
+	// 		fmt.Println("\n> current traceIds trace_id |", TRACE_ID)
 
 	// 		// ERRORS
 	// 		if transport.kind == "error" {
@@ -238,11 +265,11 @@ func setEnvelopeTraceIds(requests []Transport) {
 	// 				contexts := item.(map[string]interface{})["contexts"]
 	// 				if contexts != nil {
 	// 					trace := contexts.(map[string]interface{})["trace"]
-	// 					if currentTrace_id == trace.(map[string]interface{})["trace_id"] {
+	// 					if TRACE_ID == trace.(map[string]interface{})["trace_id"] {
 	// 						fmt.Println("\n> MATCHED trace_id BEFORE", trace.(map[string]interface{})["trace_id"])
 
-	// 						// trace.(map[string]interface{})["trace_id"] = newTraceId
-	// 						item.(map[string]interface{})["contexts"].(map[string]interface{})["trace"].(map[string]interface{})["trace_id"] = newTraceId
+	// 						// trace.(map[string]interface{})["trace_id"] = NEW_TRACE_ID
+	// 						item.(map[string]interface{})["contexts"].(map[string]interface{})["trace"].(map[string]interface{})["trace_id"] = NEW_TRACE_ID
 	// 						fmt.Println("> MATCHED trace_id AFTER", item.(map[string]interface{})["contexts"].(map[string]interface{})["trace"].(map[string]interface{})["trace_id"].(string))
 	// 					}
 	// 				}
@@ -260,3 +287,5 @@ func setEnvelopeTraceIds(requests []Transport) {
 // trace_id = "{:032x}".format(int(trace_id, 16))
 // if span_id is not None:
 // span_id = "{:016x}".format(int(span_id, 16))
+
+// item.(map[string]interface{})["contexts"].(map[string]interface{})["trace"].(map[string]interface{})["trace_id"] = NEW_TRACE_ID

--- a/transport.go
+++ b/transport.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"time"
+)
+
+// var httpClient = &http.Client{}
+
+var (
+// all         *bool
+// id          *string
+// ignore      *bool
+// database    string
+// db          *string
+// js          *string
+// py          *string
+// dsn         DSN
+// SENTRY_URL  string
+)
+
+// TODO maybe?
+type Theencoder interface {
+	encodeit() []byte
+}
+
+type Transport struct {
+	kind          string
+	platform      string
+	eventHeaders  map[string]string
+	storeEndpoint string
+
+	bodyError   map[string]interface{}
+	bodyEncoder BodyEncoder
+
+	// TODO
+	encoded []byte
+
+	envelopeItems   []interface{}
+	envelopeEncoder EnvelopeEncoder // TODO Type or a function here?
+
+	// NO, but maybe for 'requests'
+	// envelopeItems []interface{}
+	// bodyErrors []map[string]
+}
+
+// TODO many need....
+// func (t Transport) envelopeEncoder() []byte {
+// 	return t.
+// }
+
+func encodeAndSendEvents(requests []Transport, ignore bool) {
+	fmt.Println("\n> encodeAndSendEvents ...............")
+	for _, transport := range requests {
+		// var encoded []byte
+		if transport.kind == "transaction" {
+			transport.encoded = transport.envelopeEncoder(transport.envelopeItems)
+		}
+		if transport.kind == "error" {
+			transport.encoded = transport.bodyEncoder(transport.bodyError)
+		}
+		request := buildRequest(transport.encoded, transport.eventHeaders, transport.storeEndpoint)
+
+		// TODO - the ignore flag...
+		if !ignore {
+			response, requestErr := httpClient.Do(request)
+			if requestErr != nil {
+				log.Fatal(requestErr)
+			}
+			responseData, responseDataErr := ioutil.ReadAll(response.Body)
+			if responseDataErr != nil {
+				log.Fatal(responseDataErr)
+			}
+			fmt.Printf("> KIND|RESPONSE: %s %s\n", transport.kind, string(responseData))
+		} else {
+			fmt.Printf("> %s event IGNORED \n", transport.kind)
+		}
+
+		time.Sleep(1000 * time.Millisecond)
+	}
+}
+
+func buildRequest(requestBody []byte, eventHeaders map[string]string, storeEndpoint string) *http.Request {
+	fmt.Printf("> storeEndpoint %v \n", storeEndpoint)
+	if requestBody == nil {
+		log.Fatalln("buildRequest missing requestBody")
+	}
+	if eventHeaders == nil {
+		log.Fatalln("buildRequest missing eventHeaders")
+	}
+	if storeEndpoint == "" {
+		log.Fatalln("buildRequest missing storeEndpoint")
+	}
+
+	request, errNewRequest := http.NewRequest("POST", storeEndpoint, bytes.NewReader(requestBody)) // &buf
+	if errNewRequest != nil {
+		log.Fatalln(errNewRequest)
+	}
+
+	for key, value := range eventHeaders {
+		if key != "X-Sentry-Auth" {
+			request.Header.Set(key, value)
+		}
+	}
+	return request
+}


### PR DESCRIPTION
## Done
- function for reading all TraceId's as events are processed, and saving these TraceId's in a global variable
- after processing all envelopes and saving these TraceId's, re-read all envelopes and set a New Trace Id, making sure to keep everything in-sync correctly.
- this includes updating spans which have trace_id, which allows 'View Span' button to appear and function properly. A transaction's trace_id is now the same as each span's trace_id
- remove the **Length** field or else Sentry will reject the envelope/event.
- after the **for** loop for event processing completes:
```
setEnvelopeTraceIds(requests)
encodeAndSendEvents(requests, *ignore) // sends them to Sentry.
```
- events no longer sent to Sentry per iteration of the for loop.

Initial **Processing** does not fully encode the event, but prepares it into a 'Transport.go' (for lack of a better terminology) struct, so that the TraceId's can be updated later.
```
requests := []Transport{}
```
and
```
requests = append(requests, Transport{
				kind:         event.Kind,
				platform:     event.Platform,
				eventHeaders: event.Headers,

				bodyError:     bodyError,
				storeEndpoint: storeEndpoint,
				bodyEncoder:   bodyEncoder,
			})
```
or
```
envelopeItems = removeLengthField(envelopeItems)

// fills global traceIds array
getEnvelopeTraceIds(envelopeItems)

requests = append(requests, Transport{
				kind:         event.Kind,
				platform:     event.Platform,
				eventHeaders: event.Headers,
				//event: Event

				envelopeItems:   envelopeItems,
				storeEndpoint:   storeEndpoint,
				envelopeEncoder: envelopeEncoder,
			})
```

## Next
Do need to update `X-Sentry-Trace`? Is working without that. Maybe it's just used at the client sdk level, for knowing how to associate/re-use trace_id's, i.e. propagate the context.

**Interfaces**
so can call event.encode() and not have to double-handle errors vs. transactions so much.