### PR TITLE
Demo automation compute engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ api/read
 *read
 *key.json
 *.json
+sales*
 
 .DS_Store
 *.db

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ DSN_PYTHON_CELERY=
 
 // set this here as your default or pass it at runtime using --db
 SQLITE=
+JSON=?
 ```
 
 2. `pip3 install -r ./python/requirements.txt` for the proxy  
@@ -65,7 +66,8 @@ Note - Transactions are not supported if using DSN's from `getsentry/onpremise` 
 ./bin/event-to-sentry --id=<id> -i
 ./bin/event-to-sentry --all
 ```
-or use `--js` `--py` to pass DSN's when running the executable
+or use `--js` `--py` to pass DSN's when running the executable  
+`--db` if passing a .json stored locally, otherwise it will use what's in .env for `JSON`. But right now, reads from Cloud Storage **only**  
 ```
 ./bin/event-to-sentry --all --db=am-transactions-timeout-sqlite.db
 ./bin/event-to-sentry --all --db=<path_to_.db> --js=<javascripti_DSN> --py=<python_DSN>

--- a/api/transformers.go
+++ b/api/transformers.go
@@ -147,7 +147,7 @@ func setEnvelopeTraceIds(requests []Transport) {
 		NEW_TRACE_ID := uuid4
 
 		for idx, transport := range requests {
-			fmt.Println("> TRANSPORT", idx, transport.kind, transport.platform)
+			//fmt.Println("> TRANSPORT", idx, transport.kind, transport.platform)
 
 			if transport.kind == "error" {
 				contexts := transport.bodyError["contexts"]

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -290,6 +290,7 @@ func main() {
 			envelopeItems = envelopeTimestamper(envelopeItems, event.Platform)
 			envelopeItems = envelopeReleases(envelopeItems, event.Platform, event.Kind)
 			envelopeItems = removeLengthField(envelopeItems)
+			envelopeItems = sentAt(envelopeItems)
 			getEnvelopeTraceIds(envelopeItems)
 
 			requests = append(requests, Transport{

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -91,7 +91,6 @@ func parseDSN(rawurl string) *DSN {
 
 func (d DSN) storeEndpoint() string {
 	var fullurl string
-	// if d.host == "ingest.sentry.io" {
 	if strings.Contains(d.host, "ingest.sentry.io") {
 		// TODO [1:] is for removing leading slash from sentry_key=/a971db611df44a6eaf8993d994db1996, which errors ""bad sentry DSN public key""
 		fullurl = fmt.Sprint("https://", d.host, "/api/", d.projectId, "/store/?sentry_key=", d.key[1:], "&sentry_version=7")
@@ -106,9 +105,7 @@ func (d DSN) storeEndpoint() string {
 }
 func (d DSN) envelopeEndpoint() string {
 	var fullurl string
-	// if d.host == "ingest.sentry.io" {
 	if strings.Contains(d.host, "ingest.sentry.io") {
-		// TODO [1:] is for removing leading slash from sentry_key=/a971db611df44a6eaf8993d994db1996, which errors ""bad sentry DSN public key""
 		fullurl = fmt.Sprint("https://", d.host, "/api/", d.projectId, "/envelope/?sentry_key=", d.key[1:], "&sentry_version=7")
 	}
 	if d.host == "localhost:9000" {

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -65,7 +65,8 @@ func parseDSN(rawurl string) *DSN {
 
 	var host string
 	if strings.Contains(rawurl, "ingest.sentry.io") {
-		host = "ingest.sentry.io"
+		// TODO need to slice the o87286 dynamically
+		host = "o87286.ingest.sentry.io"
 	}
 	if strings.Contains(rawurl, "@localhost:") {
 		host = "localhost:9000"
@@ -90,8 +91,10 @@ func parseDSN(rawurl string) *DSN {
 
 func (d DSN) storeEndpoint() string {
 	var fullurl string
-	if d.host == "ingest.sentry.io" {
-		fullurl = fmt.Sprint("https://", d.host, "/api/", d.projectId, "/store/?sentry_key=", d.key, "&sentry_version=7")
+	// if d.host == "ingest.sentry.io" {
+	if strings.Contains(d.host, "ingest.sentry.io") {
+		// TODO [1:] is for removing leading slash from sentry_key=/a971db611df44a6eaf8993d994db1996, which errors ""bad sentry DSN public key""
+		fullurl = fmt.Sprint("https://", d.host, "/api/", d.projectId, "/store/?sentry_key=", d.key[1:], "&sentry_version=7")
 	}
 	if d.host == "localhost:9000" {
 		fullurl = fmt.Sprint("http://", d.host, "/api/", d.projectId, "/store/?sentry_key=", d.key, "&sentry_version=7")
@@ -103,8 +106,10 @@ func (d DSN) storeEndpoint() string {
 }
 func (d DSN) envelopeEndpoint() string {
 	var fullurl string
-	if d.host == "ingest.sentry.io" {
-		fullurl = fmt.Sprint("https://", d.host, "/api/", d.projectId, "/envelope/?sentry_key=", d.key, "&sentry_version=7")
+	// if d.host == "ingest.sentry.io" {
+	if strings.Contains(d.host, "ingest.sentry.io") {
+		// TODO [1:] is for removing leading slash from sentry_key=/a971db611df44a6eaf8993d994db1996, which errors ""bad sentry DSN public key""
+		fullurl = fmt.Sprint("https://", d.host, "/api/", d.projectId, "/envelope/?sentry_key=", d.key[1:], "&sentry_version=7")
 	}
 	if d.host == "localhost:9000" {
 		fullurl = fmt.Sprint("http://", d.host, "/api/", d.projectId, "/envelope/?sentry_key=", d.key, "&sentry_version=7")

--- a/timestamps.go
+++ b/timestamps.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"math/rand"
 	"time"
 
 	"github.com/shopspring/decimal"
@@ -64,10 +65,10 @@ func updateTimestamps(body map[string]interface{}, platform string) map[string]i
 
 	// TRACE PARENT
 	parentDifference := parentEndTimestamp.Sub(parentStartTimestamp)
-	// rand.Seed(time.Now().UnixNano())
-	// percentage := 0.01 + rand.Float64()*(0.20-0.01)
-	// rate := decimal.NewFromFloat(percentage)
-	// parentDifference = parentDifference.Mul(rate.Add(decimal.NewFromFloat(1)))
+	rand.Seed(time.Now().UnixNano())
+	percentage := 0.01 + rand.Float64()*(0.20-0.01)
+	rate := decimal.NewFromFloat(percentage)
+	parentDifference = parentDifference.Mul(rate.Add(decimal.NewFromFloat(1)))
 
 	unixTimestampString := fmt.Sprint(time.Now().UnixNano())
 	// fmt.Println("*** unixTimestampString 1 ***", unixTimestampString)
@@ -111,9 +112,10 @@ func updateTimestamps(body map[string]interface{}, platform string) map[string]i
 		}
 
 		spanDifference := spanEndTimestamp.Sub(spanStartTimestamp)
-		// spanDifference = spanDifference.Mul(rate.Add(decimal.NewFromFloat(1)))
+		spanDifference = spanDifference.Mul(rate.Add(decimal.NewFromFloat(1)))
 
 		spanToParentDifference := spanStartTimestamp.Sub(parentStartTimestamp)
+		spanToParentDifference = spanToParentDifference.Mul(rate.Add(decimal.NewFromFloat(1)))
 
 		// should use newParentStartTimestamp instead of spanStartTimestamp?
 		unixTimestampString := fmt.Sprint(time.Now().UnixNano())
@@ -121,6 +123,11 @@ func updateTimestamps(body map[string]interface{}, platform string) map[string]i
 		newSpanStartTimestamp := unixTimestampDecimal.Add(spanToParentDifference)
 		newSpanEndTimestamp := newSpanStartTimestamp.Add(spanDifference)
 
+		// EXPERIMENT 1:03p
+		// newSpanStartTimestamp = newSpanStartTimestamp.Mul(rate.Add(decimal.NewFromFloat(1)))
+		// newSpanEndTimestamp = newSpanEndTimestamp.Mul(rate.Add(decimal.NewFromFloat(1)))
+
+		// TODO may need to remove, if multiplying by rate change
 		if !newSpanEndTimestamp.Sub(newSpanStartTimestamp).Equal(spanDifference) {
 			fmt.Print("\nFALSE - span BOTH", newSpanEndTimestamp.Sub(newSpanStartTimestamp))
 		}

--- a/timestamps.go
+++ b/timestamps.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/shopspring/decimal"
@@ -63,7 +62,7 @@ func updateTimestamps(body map[string]interface{}, platform string) map[string]i
 		parentEndTimestamp = decimal.NewFromFloat(body["timestamp"].(float64))
 	}
 
-	// Parent Trace
+	// TRACE PARENT
 	parentDifference := parentEndTimestamp.Sub(parentStartTimestamp)
 	// rand.Seed(time.Now().UnixNano())
 	// percentage := 0.01 + rand.Float64()*(0.20-0.01)
@@ -81,34 +80,18 @@ func updateTimestamps(body map[string]interface{}, platform string) map[string]i
 		fmt.Print("\nFALSE - parent BOTH", newParentEndTimestamp.Sub(newParentStartTimestamp))
 	}
 
-	// OG
-	// body["start_timestamp"], _ = newParentStartTimestamp.Round(7).Float64()
-	// body["timestamp"], _ = newParentEndTimestamp.Round(7).Float64()
-	// fmt.Println("\n >>>>>>>>>>>>>", newParentStartTimestamp.String())
-
-	// PR1
-	// body["start_timestamp"] = decimal.NewFromFloat(body["start_timestamp"].(float64))
-	// body["timestamp"] = decimal.NewFromFloat(body["timestamp"].(float64))
-
-	// PR2
-	// body["start_timestamp"], _ = strconv.ParseFloat(newParentStartTimestamp.String(), 64)
-	// body["timestamp"], _ = strconv.ParseFloat(newParentEndTimestamp.String(), 64)
-
-	// PR3
-	// body["start_timestamp"] = newParentStartTimestamp.String()[:7]
-	// body["timestamp"] = newParentEndTimestamp.String()[:7]
-	body["start_timestamp"], _ = strconv.ParseInt(newParentStartTimestamp.String()[:10], 10, 64)
-	body["timestamp"], _ = strconv.ParseInt(newParentEndTimestamp.String()[:10], 10, 64)
+	body["start_timestamp"], _ = newParentStartTimestamp.Round(7).Float64()
+	body["timestamp"], _ = newParentEndTimestamp.Round(7).Float64()
 
 	fmt.Println("*** body['start_timestamp'] ***", body["start_timestamp"])
 	fmt.Println("*** body['timestamp'] ***", body["timestamp"])
 
 	// Could conver back to RFC3339Nano (as that's what the python sdk uses for transactions Python Transactions use) but Floats are working and this is what happens in Javascript
 	// logging with 'decimal type for readability and convertability
-	//fmt.Printf("> updateTimestamps PARENT start_timestamp after %v (%T) \n", decimal.NewFromFloat(body["start_timestamp"].(float64)), body["start_timestamp"])
+	// fmt.Printf("> updateTimestamps PARENT start_timestamp after %v (%T) \n", decimal.NewFromFloat(body["start_timestamp"].(float64)), body["start_timestamp"])
 	// fmt.Printf("> updateTimestamps PARENT       timestamp after %v (%T) \n", decimal.NewFromFloat(body["timestamp"].(float64)), body["timestamp"])
 
-	// Spans
+	// SPANS
 	for _, span := range body["spans"].([]interface{}) {
 		sp := span.(map[string]interface{})
 		// fmt.Printf("\n> updatetimestamps SPAN start_timestamp before %v (%T)", sp["start_timestamp"], sp["start_timestamp"])
@@ -142,27 +125,8 @@ func updateTimestamps(body map[string]interface{}, platform string) map[string]i
 			fmt.Print("\nFALSE - span BOTH", newSpanEndTimestamp.Sub(newSpanStartTimestamp))
 		}
 
-		// OG
-		// sp["start_timestamp"], _ = newSpanStartTimestamp.Round(7).Float64()
-		// sp["timestamp"], _ = newSpanEndTimestamp.Round(7).Float64()
-
-		// PR1
-		//sp["start_timestamp"] = decimal.NewFromFloat(sp["start_timestamp"].(float64))
-		//sp["timestamp"] = decimal.NewFromFloat(sp["timestamp"].(float64))
-
-		// PR2
-		// strconv.ParseFloat("3.1415", 64)
-		// sp["start_timestamp"], _ = strconv.ParseFloat(newSpanStartTimestamp.String(), 64)
-		// sp["timestamp"], _ = strconv.ParseFloat(newSpanEndTimestamp.String(), 64)
-
-		// PR3
-		// sp["start_timestamp"] = newSpanStartTimestamp.String()[:7]
-		// sp["timestamp"] = newSpanEndTimestamp.String()[:7]
-		sp["start_timestamp"], _ = strconv.ParseInt(newSpanStartTimestamp.String()[:10], 10, 64)
-		sp["timestamp"], _ = strconv.ParseInt(newSpanEndTimestamp.String()[:10], 10, 64)
-
-		fmt.Printf("*** sp['start_timestamp'] %v***\n", sp["start_timestamp"])
-		fmt.Printf("*** sp['timestamp'] *** %v\n", sp["timestamp"])
+		sp["start_timestamp"], _ = newSpanStartTimestamp.Round(7).Float64()
+		sp["timestamp"], _ = newSpanEndTimestamp.Round(7).Float64()
 
 		// logging with decimal for readability and convertability
 		// fmt.Printf("\n> updatetimestamps SPAN start_timestamp after %v (%T)", decimal.NewFromFloat(sp["start_timestamp"].(float64)), sp["start_timestamp"])

--- a/timestamps.go
+++ b/timestamps.go
@@ -37,13 +37,11 @@ Float form is like 1.5914674155654302e+09
 // Errors
 func updateTimestamp(body map[string]interface{}, platform string) map[string]interface{} {
 	body["timestamp"] = time.Now().Unix()
-	fmt.Println("*** Error Timestamp GOOD ***", body["timestamp"])
 	return body
 }
 
-// TODO run 100-1000 tx's in a dataset, for better variability.
-// TODO instead of multiplying by the rate,
-// TODO reduce the range of the rates...
+// TODO instead of multiplying by the rate, reduce the range of the rates?
+
 // Transactions - keep start and end timestamps relative to each other by computing the difference and new timestamps based on that
 func updateTimestamps(body map[string]interface{}, platform string) map[string]interface{} {
 	// fmt.Printf("\n> updateTimestamps PARENT start_timestamp before %v (%T) \n", body["start_timestamp"], body["start_timestamp"])
@@ -71,9 +69,7 @@ func updateTimestamps(body map[string]interface{}, platform string) map[string]i
 	parentDifference = parentDifference.Mul(rate.Add(decimal.NewFromFloat(1)))
 
 	unixTimestampString := fmt.Sprint(time.Now().UnixNano())
-	// fmt.Println("*** unixTimestampString 1 ***", unixTimestampString)
 	newParentStartTimestamp, _ := decimal.NewFromString(unixTimestampString[:10] + "." + unixTimestampString[10:])
-	// fmt.Println("*** newParentStartTimestamp 2 ***", newParentStartTimestamp)
 
 	newParentEndTimestamp := newParentStartTimestamp.Add(parentDifference)
 
@@ -83,9 +79,6 @@ func updateTimestamps(body map[string]interface{}, platform string) map[string]i
 
 	body["start_timestamp"], _ = newParentStartTimestamp.Round(7).Float64()
 	body["timestamp"], _ = newParentEndTimestamp.Round(7).Float64()
-
-	fmt.Println("*** body['start_timestamp'] ***", body["start_timestamp"])
-	fmt.Println("*** body['timestamp'] ***", body["timestamp"])
 
 	// Could conver back to RFC3339Nano (as that's what the python sdk uses for transactions Python Transactions use) but Floats are working and this is what happens in Javascript
 	// logging with 'decimal type for readability and convertability
@@ -123,11 +116,6 @@ func updateTimestamps(body map[string]interface{}, platform string) map[string]i
 		newSpanStartTimestamp := unixTimestampDecimal.Add(spanToParentDifference)
 		newSpanEndTimestamp := newSpanStartTimestamp.Add(spanDifference)
 
-		// EXPERIMENT 1:03p
-		// newSpanStartTimestamp = newSpanStartTimestamp.Mul(rate.Add(decimal.NewFromFloat(1)))
-		// newSpanEndTimestamp = newSpanEndTimestamp.Mul(rate.Add(decimal.NewFromFloat(1)))
-
-		// TODO may need to remove, if multiplying by rate change
 		if !newSpanEndTimestamp.Sub(newSpanStartTimestamp).Equal(spanDifference) {
 			fmt.Print("\nFALSE - span BOTH", newSpanEndTimestamp.Sub(newSpanStartTimestamp))
 		}

--- a/timestamps.go
+++ b/timestamps.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/shopspring/decimal"
@@ -36,7 +37,7 @@ Float form is like 1.5914674155654302e+09
 // Errors
 func updateTimestamp(body map[string]interface{}, platform string) map[string]interface{} {
 	body["timestamp"] = time.Now().Unix()
-	// fmt.Println("*** Error Timestamp GOOD ***", body["timestamp"])
+	fmt.Println("*** Error Timestamp GOOD ***", body["timestamp"])
 	return body
 }
 
@@ -70,9 +71,9 @@ func updateTimestamps(body map[string]interface{}, platform string) map[string]i
 	// parentDifference = parentDifference.Mul(rate.Add(decimal.NewFromFloat(1)))
 
 	unixTimestampString := fmt.Sprint(time.Now().UnixNano())
-	fmt.Println("*** unixTimestampString 1 ***", unixTimestampString)
+	// fmt.Println("*** unixTimestampString 1 ***", unixTimestampString)
 	newParentStartTimestamp, _ := decimal.NewFromString(unixTimestampString[:10] + "." + unixTimestampString[10:])
-	fmt.Println("*** newParentStartTimestamp 2 ***", newParentStartTimestamp)
+	// fmt.Println("*** newParentStartTimestamp 2 ***", newParentStartTimestamp)
 
 	newParentEndTimestamp := newParentStartTimestamp.Add(parentDifference)
 
@@ -81,18 +82,30 @@ func updateTimestamps(body map[string]interface{}, platform string) map[string]i
 	}
 
 	// OG
-	body["start_timestamp"], _ = newParentStartTimestamp.Round(7).Float64()
-	body["timestamp"], _ = newParentEndTimestamp.Round(7).Float64()
-	fmt.Println("*** newParentStartTimestamp ***", body["start_timestamp"])
-	fmt.Println("*** newParentEndTimestamp ***", body["timestamp"])
+	// body["start_timestamp"], _ = newParentStartTimestamp.Round(7).Float64()
+	// body["timestamp"], _ = newParentEndTimestamp.Round(7).Float64()
+	// fmt.Println("\n >>>>>>>>>>>>>", newParentStartTimestamp.String())
 
-	// PR
+	// PR1
 	// body["start_timestamp"] = decimal.NewFromFloat(body["start_timestamp"].(float64))
 	// body["timestamp"] = decimal.NewFromFloat(body["timestamp"].(float64))
 
+	// PR2
+	// body["start_timestamp"], _ = strconv.ParseFloat(newParentStartTimestamp.String(), 64)
+	// body["timestamp"], _ = strconv.ParseFloat(newParentEndTimestamp.String(), 64)
+
+	// PR3
+	// body["start_timestamp"] = newParentStartTimestamp.String()[:7]
+	// body["timestamp"] = newParentEndTimestamp.String()[:7]
+	body["start_timestamp"], _ = strconv.ParseInt(newParentStartTimestamp.String()[:10], 10, 64)
+	body["timestamp"], _ = strconv.ParseInt(newParentEndTimestamp.String()[:10], 10, 64)
+
+	fmt.Println("*** body['start_timestamp'] ***", body["start_timestamp"])
+	fmt.Println("*** body['timestamp'] ***", body["timestamp"])
+
 	// Could conver back to RFC3339Nano (as that's what the python sdk uses for transactions Python Transactions use) but Floats are working and this is what happens in Javascript
 	// logging with 'decimal type for readability and convertability
-	// fmt.Printf("> updateTimestamps PARENT start_timestamp after %v (%T) \n", decimal.NewFromFloat(body["start_timestamp"].(float64)), body["start_timestamp"])
+	//fmt.Printf("> updateTimestamps PARENT start_timestamp after %v (%T) \n", decimal.NewFromFloat(body["start_timestamp"].(float64)), body["start_timestamp"])
 	// fmt.Printf("> updateTimestamps PARENT       timestamp after %v (%T) \n", decimal.NewFromFloat(body["timestamp"].(float64)), body["timestamp"])
 
 	// Spans
@@ -130,13 +143,26 @@ func updateTimestamps(body map[string]interface{}, platform string) map[string]i
 		}
 
 		// OG
-		sp["start_timestamp"], _ = newSpanStartTimestamp.Round(7).Float64()
-		sp["timestamp"], _ = newSpanEndTimestamp.Round(7).Float64()
+		// sp["start_timestamp"], _ = newSpanStartTimestamp.Round(7).Float64()
+		// sp["timestamp"], _ = newSpanEndTimestamp.Round(7).Float64()
 
-		// PR
+		// PR1
 		//sp["start_timestamp"] = decimal.NewFromFloat(sp["start_timestamp"].(float64))
 		//sp["timestamp"] = decimal.NewFromFloat(sp["timestamp"].(float64))
-		// fmt.Println("*** sp['start_timestamp'] ***", sp["start_timestamp"])
+
+		// PR2
+		// strconv.ParseFloat("3.1415", 64)
+		// sp["start_timestamp"], _ = strconv.ParseFloat(newSpanStartTimestamp.String(), 64)
+		// sp["timestamp"], _ = strconv.ParseFloat(newSpanEndTimestamp.String(), 64)
+
+		// PR3
+		// sp["start_timestamp"] = newSpanStartTimestamp.String()[:7]
+		// sp["timestamp"] = newSpanEndTimestamp.String()[:7]
+		sp["start_timestamp"], _ = strconv.ParseInt(newSpanStartTimestamp.String()[:10], 10, 64)
+		sp["timestamp"], _ = strconv.ParseInt(newSpanEndTimestamp.String()[:10], 10, 64)
+
+		fmt.Printf("*** sp['start_timestamp'] %v***\n", sp["start_timestamp"])
+		fmt.Printf("*** sp['timestamp'] *** %v\n", sp["timestamp"])
 
 		// logging with decimal for readability and convertability
 		// fmt.Printf("\n> updatetimestamps SPAN start_timestamp after %v (%T)", decimal.NewFromFloat(sp["start_timestamp"].(float64)), sp["start_timestamp"])

--- a/transformers.go
+++ b/transformers.go
@@ -196,7 +196,7 @@ func setEnvelopeTraceIds(requests []Transport) {
 									for _, value := range spans.([]interface{}) {
 										// fmt.Println("\n> BEFORE ", value.(map[string]interface{})["trace_id"])
 										value.(map[string]interface{})["trace_id"] = NEW_TRACE_ID
-										fmt.Println(">   SPAN Transaction trace_id AFTER", item.(map[string]interface{})["spans"].([]interface{})[0].(map[string]interface{})["trace_id"])
+										//fmt.Println(">   SPAN Transaction trace_id AFTER", item.(map[string]interface{})["spans"].([]interface{})[0].(map[string]interface{})["trace_id"])
 									}
 								}
 							}

--- a/transformers.go
+++ b/transformers.go
@@ -36,16 +36,7 @@ func sentAt(envelopeItems []interface{}) []interface{} {
 	for _, item := range envelopeItems {
 		sentAt := item.(map[string]interface{})["sent_at"]
 		if sentAt != nil {
-			unixTimestampString := fmt.Sprint(time.Now().UnixNano())
-			fmt.Println(">>>>>>>> sent_at", unixTimestampString)
-			// newTimestamp, _ := decimal.NewFromString(unixTimestampString[:10] + "." + unixTimestampString[10:])
-
-			// item.(map[string]interface{})["sent_at"] = time.Now().UnixNano()
-			// item.(map[string]interface{})["sent_at"], _ = newTimestamp.Round(7).Float64()
-			// item.(map[string]interface{})["sent_at"] = newTimestamp.String()
 			item.(map[string]interface{})["sent_at"] = time.Now().UTC()
-
-			fmt.Println("\n>>>>>>> sent_at", item.(map[string]interface{})["sent_at"])
 		}
 	}
 	return envelopeItems

--- a/transformers.go
+++ b/transformers.go
@@ -163,13 +163,13 @@ func setEnvelopeTraceIds(requests []Transport) {
 	fmt.Println("\n> setEnvelopeTraceIds <", traceIds)
 
 	for _, TRACE_ID := range traceIds {
-		fmt.Println("\n> TRACE_ID", TRACE_ID)
+		//fmt.Println("\n> TRACE_ID", TRACE_ID)
 
 		var uuid4 = strings.ReplaceAll(uuid.New().String(), "-", "")
 		NEW_TRACE_ID := uuid4
 
-		for idx, transport := range requests {
-			fmt.Println("> TRANSPORT", idx, transport.kind, transport.platform)
+		for _, transport := range requests {
+			//fmt.Println("> TRANSPORT", idx, transport.kind, transport.platform)
 
 			if transport.kind == "error" {
 				contexts := transport.bodyError["contexts"]
@@ -189,7 +189,7 @@ func setEnvelopeTraceIds(requests []Transport) {
 						trace := contexts.(map[string]interface{})["trace"]
 						if TRACE_ID == trace.(map[string]interface{})["trace_id"] {
 							trace.(map[string]interface{})["trace_id"] = NEW_TRACE_ID
-							fmt.Println(">   MATCHED Transaction trace_id AFTER", item.(map[string]interface{})["contexts"].(map[string]interface{})["trace"].(map[string]interface{})["trace_id"].(string))
+							//fmt.Println(">   MATCHED Transaction trace_id AFTER", item.(map[string]interface{})["contexts"].(map[string]interface{})["trace"].(map[string]interface{})["trace_id"].(string))
 							if _, found := item.(map[string]interface{})["spans"]; found {
 								spans := item.(map[string]interface{})["spans"]
 								if len(spans.([]interface{})) > 0 {

--- a/transformers.go
+++ b/transformers.go
@@ -32,6 +32,25 @@ func eventIds(envelopeItems []interface{}) []interface{} {
 	return envelopeItems
 }
 
+func sentAt(envelopeItems []interface{}) []interface{} {
+	for _, item := range envelopeItems {
+		sentAt := item.(map[string]interface{})["sent_at"]
+		if sentAt != nil {
+			unixTimestampString := fmt.Sprint(time.Now().UnixNano())
+			fmt.Println(">>>>>>>> sent_at", unixTimestampString)
+			// newTimestamp, _ := decimal.NewFromString(unixTimestampString[:10] + "." + unixTimestampString[10:])
+
+			// item.(map[string]interface{})["sent_at"] = time.Now().UnixNano()
+			// item.(map[string]interface{})["sent_at"], _ = newTimestamp.Round(7).Float64()
+			// item.(map[string]interface{})["sent_at"] = newTimestamp.String()
+			item.(map[string]interface{})["sent_at"] = time.Now().UTC()
+
+			fmt.Println("\n>>>>>>> sent_at", item.(map[string]interface{})["sent_at"])
+		}
+	}
+	return envelopeItems
+}
+
 func envelopeReleases(envelopeItems []interface{}, platform string, kind string) []interface{} {
 	for _, item := range envelopeItems {
 

--- a/transport.go
+++ b/transport.go
@@ -33,7 +33,7 @@ type Transport struct {
 // }
 
 func encodeAndSendEvents(requests []Transport, ignore bool) {
-	fmt.Println("\n> encodeAndSendEvents ...............")
+	fmt.Println("\n> encodeAndSendEvents")
 	for _, transport := range requests {
 		if transport.kind == "transaction" {
 			transport.encoded = transport.envelopeEncoder(transport.envelopeItems)
@@ -62,7 +62,7 @@ func encodeAndSendEvents(requests []Transport, ignore bool) {
 }
 
 func buildRequest(requestBody []byte, eventHeaders map[string]string, storeEndpoint string) *http.Request {
-	fmt.Printf("> storeEndpoint %v \n", storeEndpoint)
+	fmt.Printf("> sentry endpoint %v \n", storeEndpoint)
 	if requestBody == nil {
 		log.Fatalln("buildRequest missing requestBody")
 	}

--- a/transport.go
+++ b/transport.go
@@ -33,7 +33,7 @@ type Transport struct {
 // }
 
 func encodeAndSendEvents(requests []Transport, ignore bool) {
-	fmt.Println("\n> encodeAndSendEvents")
+	// fmt.Println("\n> encodeAndSendEvents")
 	for _, transport := range requests {
 		if transport.kind == "transaction" {
 			transport.encoded = transport.envelopeEncoder(transport.envelopeItems)


### PR DESCRIPTION
## Fixed
#### Ingest URL
- removed leading slash from DSN public key
- added string prefix to `ingest.sentry.io`

#### Timestamp Clock
Now updating `sent_at` property on the first item of every envelope (Transaction) so no longer get Warning in the Sentry UI about clock drift or invalid timestamps.

#### Randomization of Timestamps
Added Randomization to `spanToParentDifference` it was missing! 
```
spanDifference := spanEndTimestamp.Sub(spanStartTimestamp)
spanDifference = spanDifference.Mul(rate.Add(decimal.NewFromFloat(1)))

spanToParentDifference := spanStartTimestamp.Sub(parentStartTimestamp)
spanToParentDifference = spanToParentDifference.Mul(rate.Add(decimal.NewFromFloat(1)))
```
Now the Trace Parent and Spans are:
- properly randomized
- align property from left to right
- stay relative to each other
- eliminated gaps

## Note
See randomization-of-timestamps-1 and randomization-of-timestamps-2 in Loom to note that the original timestamps sometimes leave gaps, so certain gaps can not be attributed to improper randomization of timestamps.