### PR TITLE
Json files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ sales*
 
 .DS_Store
 *.db
+
+*.sh

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ go build -o bin/event-to-sentry-tracing-example *.go
 Note - Transactions are not supported if using DSN's from `getsentry/onpremise` as of 07/08/20
 
 ## Run Locally
+`go build -o bin/sdk-upgrade *.go && ./bin/sdk-upgrade -i`
+
 ```
 ./bin/event-to-sentry-<name>
 ./bin/event-to-sentry
@@ -73,7 +75,7 @@ or use `--js` `--py` to pass DSN's when running the executable
 ./bin/event-to-sentry --all --db=<path_to_.db> --js=<javascripti_DSN> --py=<python_DSN>
 ```
 
-`go build -o bin/sdk-upgrade *.go && ./bin/sdk-upgrade -i`
+
 
 See your events in Sentry
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ or use `--js` `--py` to pass DSN's when running the executable
 ./bin/event-to-sentry --all --db=<path_to_.db> --js=<javascripti_DSN> --py=<python_DSN>
 ```
 
+`go build -o bin/sdk-upgrade *.go && ./bin/sdk-upgrade -i`
+
 See your events in Sentry
 
 ## Run in Cloud Function

--- a/error.go
+++ b/error.go
@@ -19,18 +19,16 @@ type Error struct {
 	Platform string `json:"platform"`
 }
 
-func (e Error) eventId() Error {
+func (e *Error) eventId() {
 	// if _, ok := e.EventId; !ok {
 	// 	log.Print("no event_id on object from DB")
 	// }
 	var uuid4 = strings.ReplaceAll(uuid.New().String(), "-", "")
 	e.EventId = uuid4
-	// fmt.Println("\n> event_id updated", e.EventId)
-	return e
 }
 
 // CalVer https://calver.org/
-func (e Error) release() Error {
+func (e *Error) release() {
 	date := time.Now()
 	month := date.Month()
 	day := date.Day()
@@ -47,17 +45,15 @@ func (e Error) release() Error {
 	}
 	release := fmt.Sprint(int(month), ".", week)
 	e.Release = release
-	return e
 }
 
-func (e Error) user() Error {
+func (e *Error) user() {
 	e.User = make(map[string]interface{})
 	user := e.User //.(map[string]interface{})
 	user["email"] = createUser()
-	return e
 }
 
-func (e Error) setTimestamp() Error {
+func (e *Error) setTimestamp() {
 	timestamp := fmt.Sprint(time.Now().Unix())
 	timestampDecimal, err1 := decimal.NewFromString(timestamp[:10] + "." + timestamp[10:])
 	fmt.Print("> timestampDecimal\n", timestampDecimal)
@@ -69,5 +65,4 @@ func (e Error) setTimestamp() Error {
 		log.Fatal(err2)
 	}
 	e.Timestamp = timestampFinal
-	return e
 }

--- a/error.go
+++ b/error.go
@@ -16,6 +16,7 @@ type Error struct {
 	User      map[string]interface{} `json:"user"`
 	Timestamp float64                `json:"timestamp"`
 	// Type      string                 `json:"type"`
+	Platform string `json:"platform"`
 }
 
 func (e Error) eventId() Error {

--- a/error.go
+++ b/error.go
@@ -60,7 +60,7 @@ func (e Error) user() Error {
 func (e Error) setTimestamp() Error {
 	timestamp := fmt.Sprint(time.Now().Unix())
 	timestampDecimal, err1 := decimal.NewFromString(timestamp[:10] + "." + timestamp[10:])
-	fmt.Print("> timestampDecimal", timestampDecimal)
+	fmt.Print("> timestampDecimal\n", timestampDecimal)
 	if err1 != nil {
 		log.Fatal(err1)
 	}

--- a/error.go
+++ b/error.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Error struct {
+	EventId   string                 `json:"event_id"`
+	Release   string                 `json:"release"`
+	User      map[string]interface{} `json:"user"`
+	Timestamp int64                  `json:"timestamp"`
+	// Type      string                 `json:"type"`
+}
+
+func (e Error) eventId() Error {
+	// if _, ok := e.EventId; !ok {
+	// 	log.Print("no event_id on object from DB")
+	// }
+	var uuid4 = strings.ReplaceAll(uuid.New().String(), "-", "")
+	e.EventId = uuid4
+	fmt.Println("\n> event_id updated", e.EventId)
+	return e
+}
+
+// CalVer https://calver.org/
+func (e Error) release() Error {
+	date := time.Now()
+	month := date.Month()
+	day := date.Day()
+	var week int
+	switch {
+	case day <= 7:
+		week = 1
+	case day >= 8 && day <= 14:
+		week = 2
+	case day >= 15 && day <= 21:
+		week = 3
+	case day >= 22:
+		week = 4
+	}
+	release := fmt.Sprint(int(month), ".", week)
+	e.Release = release
+	return e
+}
+
+func (e Error) user() Error {
+	e.User = make(map[string]interface{})
+	user := e.User //.(map[string]interface{})
+	user["email"] = createUser()
+	return e
+}
+
+func (e Error) setTimestamp() Error {
+	e.Timestamp = time.Now().Unix()
+	return e
+}

--- a/error.go
+++ b/error.go
@@ -2,17 +2,19 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
 )
 
 type Error struct {
 	EventId   string                 `json:"event_id"`
 	Release   string                 `json:"release"`
 	User      map[string]interface{} `json:"user"`
-	Timestamp int64                  `json:"timestamp"`
+	Timestamp float64                `json:"timestamp"`
 	// Type      string                 `json:"type"`
 }
 
@@ -22,7 +24,7 @@ func (e Error) eventId() Error {
 	// }
 	var uuid4 = strings.ReplaceAll(uuid.New().String(), "-", "")
 	e.EventId = uuid4
-	fmt.Println("\n> event_id updated", e.EventId)
+	// fmt.Println("\n> event_id updated", e.EventId)
 	return e
 }
 
@@ -55,6 +57,16 @@ func (e Error) user() Error {
 }
 
 func (e Error) setTimestamp() Error {
-	e.Timestamp = time.Now().Unix()
+	timestamp := fmt.Sprint(time.Now().Unix())
+	timestampDecimal, err1 := decimal.NewFromString(timestamp[:10] + "." + timestamp[10:])
+	fmt.Print("> timestampDecimal", timestampDecimal)
+	if err1 != nil {
+		log.Fatal(err1)
+	}
+	timestampFinal, err2 := timestampDecimal.Round(7).Float64()
+	if err2 == false {
+		log.Fatal(err2)
+	}
+	e.Timestamp = timestampFinal
 	return e
 }

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -121,7 +121,7 @@ type EventJson struct {
 	EventId   string                 `json:"event_id"`
 	Release   string                 `json:"release"`
 	User      map[string]interface{} `json:"user"`
-	Timestamp string                 `json:"timestamp"`
+	Timestamp int64                  `json:"timestamp"` // not float64?
 	Type      string                 `json:"type"`
 }
 type Event struct {

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -118,7 +118,7 @@ func (d DSN) envelopeEndpoint() string {
 }
 
 type EventJson struct {
-	eventId string `json:"eventId"`
+	EventId string `json:"event_id"`
 }
 type Event struct {
 	Platform string            `json:"platform"`

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -186,31 +186,31 @@ type Timestamp struct {
 	rfc3339 bool
 }
 
-type Item struct {
-	Timestamp Timestamp `json:"timestamp,omitempty"`
-	// Timestamp time.Time `json:"timestamp,omitempty"`
+// type Item struct {
+// 	Timestamp Timestamp `json:"timestamp,omitempty"`
+// 	// Timestamp time.Time `json:"timestamp,omitempty"`
 
-	Event_id string `json:"event_id,omitempty"`
-	Sent_at  string `json:"sent_at,omitempty"`
+// 	Event_id string `json:"event_id,omitempty"`
+// 	Sent_at  string `json:"sent_at,omitempty"`
 
-	Length       int    `json:"length,omitempty"`
-	Type         string `json:"type,omitempty"`
-	Content_type string `json:"content_type,omitempty"`
+// 	Length       int    `json:"length,omitempty"`
+// 	Type         string `json:"type,omitempty"`
+// 	Content_type string `json:"content_type,omitempty"`
 
-	Start_timestamp string                 `json:"start_timestamp,omitempty"`
-	Transaction     string                 `json:"transaction,omitempty"`
-	Server_name     string                 `json:"server_name,omitempty"`
-	Tags            map[string]interface{} `json:"tags,omitempty"`
-	Contexts        map[string]interface{} `json:"contexts,omitempty"`
+// 	Start_timestamp string                 `json:"start_timestamp,omitempty"`
+// 	Transaction     string                 `json:"transaction,omitempty"`
+// 	Server_name     string                 `json:"server_name,omitempty"`
+// 	Tags            map[string]interface{} `json:"tags,omitempty"`
+// 	Contexts        map[string]interface{} `json:"contexts,omitempty"`
 
-	Extra       map[string]interface{} `json:"extra,omitempty"`
-	Request     map[string]interface{} `json:"request,omitempty"`
-	Environment string                 `json:"environment,omitempty"`
-	Platform    string                 `json:"platform,omitempty"`
-	// Todo spans []
-	Sdk  map[string]interface{} `json:"sdk,omitempty"`
-	User map[string]interface{} `json:"user,omitempty"`
-}
+// 	Extra       map[string]interface{} `json:"extra,omitempty"`
+// 	Request     map[string]interface{} `json:"request,omitempty"`
+// 	Environment string                 `json:"environment,omitempty"`
+// 	Platform    string                 `json:"platform,omitempty"`
+// 	// Todo spans []
+// 	Sdk  map[string]interface{} `json:"sdk,omitempty"`
+// 	User map[string]interface{} `json:"user,omitempty"`
+// }
 
 // TODO need an ItemFinal that has unified timestamp?
 

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -94,6 +94,7 @@ func (d DSN) storeEndpoint() string {
 	if strings.Contains(d.host, "ingest.sentry.io") {
 		// TODO [1:] is for removing leading slash from sentry_key=/a971db611df44a6eaf8993d994db1996, which errors ""bad sentry DSN public key""
 		fullurl = fmt.Sprint("https://", d.host, "/api/", d.projectId, "/store/?sentry_key=", d.key[1:], "&sentry_version=7")
+		// fullurl = fmt.Sprint("https://", d.host, "/api/", d.projectId, "/store/?sentry_key=", d.key[1:])
 	}
 	if d.host == "localhost:9000" {
 		fullurl = fmt.Sprint("http://", d.host, "/api/", d.projectId, "/store/?sentry_key=", d.key, "&sentry_version=7")
@@ -253,7 +254,7 @@ func main() {
 	// 	log.Fatal(err)
 	// }
 
-	readJsons()
+	readJsons(*ignore)
 	return
 
 	// CLOUD STORAGE

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -123,6 +123,7 @@ type EventJson struct {
 	User      map[string]interface{} `json:"user"`
 	Timestamp float64                `json:"timestamp"`
 	Type      string                 `json:"type"`
+	Platform  string                 `json:"platform"`
 }
 type Event struct {
 	Platform string            `json:"platform"`
@@ -134,7 +135,17 @@ type Event struct {
 func (e Event) String() string {
 	return fmt.Sprintf("\n Event { Platform: %s, Type: %s }\n", e.Platform, e.Kind) // index somehow?
 }
-
+func findDSN(projectDSNs map[string]*DSN, platform string) string {
+	// var storeEndpoint string
+	if platform == "javascript" {
+		return projectDSNs["javascript"].storeEndpoint()
+	} else if platform == "python" {
+		return projectDSNs["python"].storeEndpoint()
+	} else {
+		log.Fatal("platform type not supported")
+	}
+	return ""
+}
 func matchDSN(projectDSNs map[string]*DSN, event Event) string {
 
 	platform := event.Platform
@@ -287,8 +298,9 @@ func main() {
 				platform:      event.Platform,
 				eventHeaders:  event.Headers,
 				storeEndpoint: storeEndpoint,
-				bodyError:     bodyError,
-				bodyEncoder:   bodyEncoder,
+
+				bodyError:   bodyError,
+				bodyEncoder: bodyEncoder,
 			})
 
 		} else if event.Kind == "transaction" {
@@ -302,10 +314,11 @@ func main() {
 			getEnvelopeTraceIds(envelopeItems)
 
 			requests = append(requests, Transport{
-				kind:            event.Kind,
-				platform:        event.Platform,
-				eventHeaders:    event.Headers,
-				storeEndpoint:   storeEndpoint,
+				kind:          event.Kind,
+				platform:      event.Platform,
+				eventHeaders:  event.Headers,
+				storeEndpoint: storeEndpoint,
+
 				envelopeItems:   envelopeItems,
 				envelopeEncoder: envelopeEncoder,
 			})

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -117,6 +117,9 @@ func (d DSN) envelopeEndpoint() string {
 	return fullurl
 }
 
+type EventJson struct {
+	eventId string `json:"eventId"`
+}
 type Event struct {
 	Platform string            `json:"platform"`
 	Kind     string            `json:"kind"`
@@ -234,6 +237,9 @@ func main() {
 	// if err != nil {
 	// 	log.Fatal(err)
 	// }
+
+	readJsons()
+	return
 
 	// CLOUD STORAGE
 	bucket := os.Getenv("BUCKET")

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -118,7 +118,11 @@ func (d DSN) envelopeEndpoint() string {
 }
 
 type EventJson struct {
-	EventId string `json:"event_id"`
+	EventId   string                 `json:"event_id"`
+	Release   string                 `json:"release"`
+	User      map[string]interface{} `json:"user"`
+	Timestamp string                 `json:"timestamp"`
+	Type      string                 `json:"type"`
 }
 type Event struct {
 	Platform string            `json:"platform"`

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -237,7 +237,7 @@ func main() {
 
 	// CLOUD STORAGE
 	bucket := os.Getenv("BUCKET")
-	object := "npm-sentry-tracing.json"
+	object := database
 	fmt.Println("DATASET object", object)
 	ctx := context.Background()
 	client, err := storage.NewClient(ctx)

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -135,7 +135,7 @@ type Event struct {
 func (e Event) String() string {
 	return fmt.Sprintf("\n Event { Platform: %s, Type: %s }\n", e.Platform, e.Kind) // index somehow?
 }
-func findDSN(projectDSNs map[string]*DSN, platform string) string {
+func dsnToStoreEndpoint(projectDSNs map[string]*DSN, platform string) string {
 	// var storeEndpoint string
 	if platform == "javascript" {
 		return projectDSNs["javascript"].storeEndpoint()

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -121,7 +121,7 @@ type EventJson struct {
 	EventId   string                 `json:"event_id"`
 	Release   string                 `json:"release"`
 	User      map[string]interface{} `json:"user"`
-	Timestamp int64                  `json:"timestamp"` // not float64?
+	Timestamp float64                `json:"timestamp"`
 	Type      string                 `json:"type"`
 }
 type Event struct {

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de // indirect
 	golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1 // indirect
 	golang.org/x/tools v0.0.0-20200731060945-b5fad4ed8dd6 // indirect
+	google.golang.org/api v0.29.0
 	google.golang.org/appengine v1.6.6 // indirect
 	google.golang.org/genproto v0.0.0-20200731012542-8145dea6a485 // indirect
 	google.golang.org/grpc v1.31.0 // indirect

--- a/python/proxy.py
+++ b/python/proxy.py
@@ -179,10 +179,10 @@ def save_envelope():
         for key in ['Accept-Encoding','Content-Length','Content-Type','User-Agent']:
             request_headers[key] = request.headers.get(key)
         body = request.data.decode("utf-8")
-
+    
     print(type(json.dumps(body)))
-
-    o = {
+    
+    event = {
         'platform': event_platform,
         'kind': event_type,
         'headers': request_headers,
@@ -193,11 +193,14 @@ def save_envelope():
         with open(JSON) as file:
             current_data = json.load(file)
         with open(JSON, 'w') as file:
-            current_data.append(o)
+            current_data.append(event)
             json.dump(current_data, file)
 
     except Exception as exception:
         print("LOCAL EXCEPTION", exception)
+        print("LOCAL EXCEPTION event_platform:", event_platform)
+        print("LOCAL EXCEPTION event_type:", event_type)
+        
     return "success"
 
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -3,4 +3,4 @@ flask_cors==3.0.8
 psycopg2-binary==2.8.4
 python-dotenv==0.12.0
 requests==2.18.4
-sentry-sdk==0.14.2
+sentry-sdk==0.19.2

--- a/python/services.py
+++ b/python/services.py
@@ -31,11 +31,9 @@ def compress_gzip(dict_body):
 def get_event_type(payload, platform):
     body_dict = ''
     if platform == 'python':
-        print('\n****** PYTHON ')
         body_dict = decompress_gzip(payload)
         # body_dict = json.loads(decompress_gzip(payload))
     if platform == 'javascript':
-        print('\n****** JAVASCRIPT ')
         envelope = payload
         print('type(envelope) ist still bytes, so decode it', type(envelope))
 

--- a/read-jsons.go
+++ b/read-jsons.go
@@ -17,9 +17,7 @@ import (
 https://cloud.google.com/appengine/docs/standard/go111/googlecloudstorageclient/read-write-to-cloud-storage
 https://github.com/GoogleCloudPlatform/golang-samples/blob/8deb2909eadf32523007fd8fe9e8755a12c6d463/docs/appengine/storage/app.go
 */
-func readJsons() string {
-	fmt.Println("This is a readJsons test...")
-
+func readJsons(ignore bool) string {
 	bucketName := os.Getenv("BUCKET")
 
 	// Initialize/Connect the Client
@@ -65,11 +63,9 @@ func readJsons() string {
 		if err := json.Unmarshal(byteValue, &event); err != nil { // TODO float64 vs int64
 			panic(err)
 		}
-
+		fmt.Printf("\n> > > > > > >  EVENT > > > >  %+v \n", event)
 		events = append(events, event)
 	}
-
-	// fmt.Println(">>>>> events []EventJson", len(events))
 
 	requests := []Request{}
 
@@ -78,15 +74,22 @@ func readJsons() string {
 		if event.Type == "error" {
 			fmt.Println("> error")
 			eventError := Error{event.EventId, event.Release, event.User, event.Timestamp, event.Platform}
-			eventError.eventId()
-			eventError.release()
-			eventError.user()
-			eventError.setTimestamp()
 
-			// storeEndpoint := findDSN(projectDSNs, eventError.Platform)
+			fmt.Println("\n> event_id BEFORE", eventError.EventId)
+			eventError.eventId()
+			fmt.Println("\n> event_id AFTER", eventError.EventId)
+
+			// eventError.release()
+			// eventError.user()
+
+			fmt.Println("\n> timestamp BEFORE", eventError.Timestamp)
+			eventError.setTimestamp()
+			fmt.Println("\n> timestamp AFTER", eventError.Timestamp)
+
 			requests = append(requests, Request{
 				errorPayload:  eventError,
 				storeEndpoint: dsnToStoreEndpoint(projectDSNs, eventError.Platform),
+				// sentryAuthKey:
 			})
 		}
 		if event.Type == "transaction" {
@@ -102,7 +105,7 @@ func readJsons() string {
 		}
 	}
 
-	sendRequests(requests)
+	sendRequests(requests, ignore)
 	return "\n DONE \n"
 }
 

--- a/read-jsons.go
+++ b/read-jsons.go
@@ -83,10 +83,10 @@ func readJsons() string {
 			eventError.user()
 			eventError.setTimestamp()
 
-			storeEndpoint := findDSN(projectDSNs, eventError.Platform)
+			// storeEndpoint := findDSN(projectDSNs, eventError.Platform)
 			requests = append(requests, Request{
 				errorPayload:  eventError,
-				storeEndpoint: storeEndpoint,
+				storeEndpoint: dsnToStoreEndpoint(projectDSNs, eventError.Platform),
 			})
 		}
 		if event.Type == "transaction" {

--- a/read-jsons.go
+++ b/read-jsons.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"time"
+
+	"cloud.google.com/go/storage"
+)
+
+func readJsons() string {
+	fmt.Println("This is a readJsons test...")
+
+	bucket := os.Getenv("BUCKET")
+
+	// Initialize/Connect the Client
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		log.Fatalln("storage.NewClient:", err)
+	}
+	defer client.Close()
+	ctx, cancel := context.WithTimeout(ctx, time.Second*50)
+	defer cancel()
+
+	// TODO
+	// 1 List all files for bucket...
+
+	// 2. iterate through each and add to global...
+
+	file := database
+	fmt.Println("DATASET file", file)
+	rc, err := client.Bucket(bucket).Object(file).NewReader(ctx)
+	if err != nil {
+		log.Fatalln("NewReader:", err)
+	}
+	byteValue, _ := ioutil.ReadAll(rc) // jsonFile
+	// defer jsonFile.Close()
+	events := make([]EventJson, 0)
+	if err := json.Unmarshal(byteValue, &events); err != nil {
+		panic(err)
+	}
+
+	return "read those jsons"
+}

--- a/read-jsons.go
+++ b/read-jsons.go
@@ -73,7 +73,23 @@ func readJsons() string {
 
 	fmt.Println(">>>>> events []EventJson", len(events))
 	for _, e := range events {
+		// match DSN based on js vs python
+		// decide Errors vs Transaction. if error.... make an Error struct. if transaction.... make a Transaction struct.... call methods on both
+		// if e.Type == "error" {
+
+		// }
+		// if e.Type == "transaction" {
+
+		// }
+
 		fmt.Println("> event.eventId", e.EventId)
+		// TODO
+		// assuming Error
+		// event = eventId(event) // would be error.eventId(), error.release(), error.user(), error.timestamp()
+		// event = release(event)
+		// event = user(event)
+		// event = updateTimestamp(event)
+
 	}
 
 	return "read those jsons"

--- a/read-jsons.go
+++ b/read-jsons.go
@@ -2,20 +2,23 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"time"
 
 	"cloud.google.com/go/storage"
+	"google.golang.org/api/iterator"
 )
 
+/*
+https://cloud.google.com/appengine/docs/standard/go111/googlecloudstorageclient/read-write-to-cloud-storage
+https://github.com/GoogleCloudPlatform/golang-samples/blob/8deb2909eadf32523007fd8fe9e8755a12c6d463/docs/appengine/storage/app.go
+*/
 func readJsons() string {
 	fmt.Println("This is a readJsons test...")
 
-	bucket := os.Getenv("BUCKET")
+	bucketName := os.Getenv("BUCKET")
 
 	// Initialize/Connect the Client
 	ctx := context.Background()
@@ -27,23 +30,52 @@ func readJsons() string {
 	ctx, cancel := context.WithTimeout(ctx, time.Second*50)
 	defer cancel()
 
-	// TODO
-	// 1 List all files for bucket...
+	// Prepare bucket handle
+	bucketHandle := client.Bucket(bucketName)
 
-	// 2. iterate through each and add to global...
+	// lists the contents of a bucket in Google Cloud Storage.
+	query := &storage.Query{Prefix: "event"}
+	it := bucketHandle.Objects(ctx, query)
+	for {
+		obj, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			log.Fatal("listBucket: unable to list bucket %q: %v", bucketHandle, err)
+		}
+		printObj(obj)
+		// fmt.Println(">>>>> obj", obj)
+		// d.dumpStats(obj)
+	}
 
-	file := database
-	fmt.Println("DATASET file", file)
-	rc, err := client.Bucket(bucket).Object(file).NewReader(ctx)
-	if err != nil {
-		log.Fatalln("NewReader:", err)
-	}
-	byteValue, _ := ioutil.ReadAll(rc) // jsonFile
-	// defer jsonFile.Close()
-	events := make([]EventJson, 0)
-	if err := json.Unmarshal(byteValue, &events); err != nil {
-		panic(err)
-	}
+	// read each file content
+	// file := database
+	// fmt.Println("DATASET file", file)
+	// rc, err := client.Bucket(bucket).Object(file).NewReader(ctx)
+	// if err != nil {
+	// 	log.Fatalln("NewReader:", err)
+	// }
+	// byteValue, _ := ioutil.ReadAll(rc) // jsonFile
+	// // defer jsonFile.Close()
+	// events := make([]EventJson, 0)
+	// if err := json.Unmarshal(byteValue, &events); err != nil {
+	// 	panic(err)
+	// }
 
 	return "read those jsons"
+}
+
+func printObj(obj *storage.ObjectAttrs) {
+	fmt.Printf("(filename: /%v/%v, \n", obj.Bucket, obj.Name)
+	// fmt.Printf("ContentType: %q, ", obj.ContentType)
+	// fmt.Printf("ACL: %#v, ", obj.ACL)
+	// fmt.Printf("Owner: %v, ", obj.Owner)
+	// fmt.Printf("ContentEncoding: %q, ", obj.ContentEncoding)
+	// fmt.Printf("Size: %v, ", obj.Size)
+	// fmt.Printf("MD5: %q, ", obj.MD5)
+	// fmt.Printf("CRC32C: %q, ", obj.CRC32C)
+	// fmt.Printf("Metadata: %#v, ", obj.Metadata)
+	// fmt.Printf("MediaLink: %q, ", obj.MediaLink)
+	// fmt.Printf("StorageClass: %q, ", obj.StorageClass)
 }

--- a/read-jsons.go
+++ b/read-jsons.go
@@ -72,24 +72,30 @@ func readJsons() string {
 	}
 
 	fmt.Println(">>>>> events []EventJson", len(events))
-	for _, e := range events {
+	for _, event := range events {
 		// match DSN based on js vs python
-		// decide Errors vs Transaction. if error.... make an Error struct. if transaction.... make a Transaction struct.... call methods on both
-		// if e.Type == "error" {
+		if event.Type == "error" {
+			fmt.Println("> error")
+			eventError := Error{event.EventId, event.Release, event.User, event.Timestamp}
+			eventError.eventId()
+			eventError.release()
+			eventError.user()
+			eventError.setTimestamp()
+		}
+		if event.Type == "transaction" {
+			fmt.Println("> transaction")
+			eventTransaction := Transaction{event.EventId, event.Release, event.User, event.Timestamp}
+			eventTransaction.eventIds()
+			eventTransaction.setReleases()
+			eventTransaction.setUsers()
+			eventTransaction.setTimestamps()
 
-		// }
-		// if e.Type == "transaction" {
+			eventTransaction.sentAt()
+			eventTransaction.removeLengthField()
 
-		// }
+		}
 
-		fmt.Println("> event.eventId", e.EventId)
-		// TODO
-		// assuming Error
-		// event = eventId(event) // would be error.eventId(), error.release(), error.user(), error.timestamp()
-		// event = release(event)
-		// event = user(event)
-		// event = updateTimestamp(event)
-
+		fmt.Println("> event.eventId", event.EventId)
 	}
 
 	return "read those jsons"

--- a/request.go
+++ b/request.go
@@ -1,0 +1,5 @@
+package main
+
+type Request struct {
+	event EventJson
+}

--- a/request.go
+++ b/request.go
@@ -26,10 +26,12 @@ func (r Request) sendRequest() bool {
 	if errNewRequest != nil {
 		log.Fatalln(errNewRequest)
 	}
-	// eventHeaders := [2]string{"content-type", "x-sentry-auth"}
+	// fmt.Printf("*** storeEndpoint *** %v\n", r.storeEndpoint)
+	fmt.Printf("\n*** storeEndpoint *** %v\n", r.storeEndpoint)
+	fmt.Printf("*** x-sentry-auth *** %v\n", os.Getenv("SENTRY_AUTH_KEY"))
+
 	request.Header.Set("content-type", "application/json")
-	fmt.Printf("*** SENTRY_AUTH_KEY ***\n", os.Getenv("SENTRY_AUTH_KEY"))
-	request.Header.Set("x-sentry-auth", os.Getenv("SENTRY_AUTH_KEY"))
+	// request.Header.Set("x-sentry-auth", os.Getenv("SENTRY_AUTH_KEY"))
 
 	// for _, key := range eventHeaders {
 	// // if key != "x-Sentry-Auth" {

--- a/request.go
+++ b/request.go
@@ -1,5 +1,56 @@
 package main
 
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+)
+
 type Request struct {
-	event EventJson
+	errorPayload       Error
+	transactionPayload Transaction
+	storeEndpoint      string
+}
+
+func (r Request) sendRequest() bool {
+
+	bodyBytes, errBodyBytes := json.Marshal(r.errorPayload)
+	if errBodyBytes != nil {
+		fmt.Println(errBodyBytes)
+	}
+	request, errNewRequest := http.NewRequest("POST", r.storeEndpoint, bytes.NewReader(bodyBytes)) // &buf
+	if errNewRequest != nil {
+		log.Fatalln(errNewRequest)
+	}
+	// eventHeaders := [2]string{"content-type", "x-sentry-auth"}
+	request.Header.Set("content-type", "application/json")
+	fmt.Printf("*** SENTRY_AUTH_KEY ***\n", os.Getenv("SENTRY_AUTH_KEY"))
+	request.Header.Set("x-sentry-auth", os.Getenv("SENTRY_AUTH_KEY"))
+
+	// for _, key := range eventHeaders {
+	// // if key != "x-Sentry-Auth" {
+	// request.Header.Set(key, "asdf")
+	// // }
+	// }
+	response, requestErr := httpClient.Do(request)
+	if requestErr != nil {
+		log.Fatal(requestErr)
+	}
+	responseData, responseDataErr := ioutil.ReadAll(response.Body)
+	if responseDataErr != nil {
+		log.Fatal(responseDataErr)
+	}
+	fmt.Printf("> KIND|RESPONSE: %s \n", string(responseData))
+	return true
+}
+
+func sendRequests(requests []Request) bool {
+	for _, request := range requests {
+		request.sendRequest()
+	}
+	return true
 }

--- a/transaction.go
+++ b/transaction.go
@@ -1,0 +1,9 @@
+package main
+
+type Transaction struct {
+	EventId   string                 `json:"event_id"`
+	Release   string                 `json:"release"`
+	User      map[string]interface{} `json:"user"`
+	Timestamp int64                  `json:"timestamp"`
+	// Type      string                 `json:"type"`
+}

--- a/transformers.go
+++ b/transformers.go
@@ -70,7 +70,7 @@ func envelopeReleases(envelopeItems []interface{}, platform string, kind string)
 	return envelopeItems
 }
 
-// CalVer-lite
+// CalVer https://calver.org/
 func release(body map[string]interface{}) map[string]interface{} {
 	date := time.Now()
 	month := date.Month()

--- a/transformers.go
+++ b/transformers.go
@@ -26,6 +26,7 @@ func eventIds(envelopeItems []interface{}) []interface{} {
 	for _, item := range envelopeItems {
 		eventId := item.(map[string]interface{})["event_id"]
 		if eventId != nil {
+			fmt.Println("\n> event_id eventIds", uuid4)
 			item.(map[string]interface{})["event_id"] = uuid4
 		}
 	}


### PR DESCRIPTION
## Description
New process in place, which gets rid of running the 'proxy' interceptor.

THis PR allows you to download the JSON format of an event (post-ingestion) and put that into GCS, so then the Go script can read those and send to Sentry.

Previously, a single JSON Array (one single json file) contained all the transactions+events, and there were envelopes in that.

But now, everything can be sent to the old `/store` endpoint, both Transactions+Events. No `encoder` `decoder` functionality needed anymore.

## Todo
`struct EventJSON` to `struct Error` or `struct Transaction`

## Testing
todo

## For Example
Now using this:
```
type EventJson struct {
	EventId   string                 `json:"event_id"`
	Release   string                 `json:"release"`
	User      map[string]interface{} `json:"user"`
	Timestamp string                 `json:"timestamp"`
}
```
instead of:
```
type Event struct {
	Platform string            `json:"platform"`
	Kind     string            `json:"kind"`
	Headers  map[string]string `json:"headers"`
	Body     string            `json:"body"`
}
```

Also...use this property to decide if it's a Transaction vs Error, no longer need to use Event.Kind:
```
"type": "transaction"
```