### PR TITLE
Refactor for Store Endpoint for Errors and Transactions from Json Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ sales*
 
 .DS_Store
 *.db
+
+*.sh

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ go build -o bin/event-to-sentry-tracing-example *.go
 Note - Transactions are not supported if using DSN's from `getsentry/onpremise` as of 07/08/20
 
 ## Run Locally
+`go build -o bin/sdk-upgrade *.go && ./bin/sdk-upgrade -i`
+
 ```
 ./bin/event-to-sentry-<name>
 ./bin/event-to-sentry
@@ -73,7 +75,7 @@ or use `--js` `--py` to pass DSN's when running the executable
 ./bin/event-to-sentry --all --db=<path_to_.db> --js=<javascripti_DSN> --py=<python_DSN>
 ```
 
-`go build -o bin/sdk-upgrade *.go && ./bin/sdk-upgrade -i`
+
 
 See your events in Sentry
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ or use `--js` `--py` to pass DSN's when running the executable
 ./bin/event-to-sentry --all --db=<path_to_.db> --js=<javascripti_DSN> --py=<python_DSN>
 ```
 
+`go build -o bin/sdk-upgrade *.go && ./bin/sdk-upgrade -i`
+
 See your events in Sentry
 
 ## Run in Cloud Function

--- a/error.go
+++ b/error.go
@@ -12,7 +12,8 @@ import (
 
 /*
 Post-Ingestion from https://sentry.io/api/0/projects/<org>/<project>/events/<event_id>/json/
-skip _meta, _metrics, errors
+Either don't sound needed or give 'Discarded unknown attribute'
+skip _meta, _metrics, errors, location, title
 */
 type Error struct {
 	EventId   string                 `json:"event_id"`
@@ -37,8 +38,12 @@ type Error struct {
 	Hashes          []string               `json:"hashes"`          // nothing new but also no processing error warnings
 	Key_id          string                 `json:"key_id"`
 	Level           string                 `json:"level"`
-	Location        string                 `json:"location"`
 	Logger          string                 `json:"logger"`
+	Metadata        map[string]interface{} `json:"metadata"`
+	Received        float64                `json:"received"`
+	Request         map[string]interface{} `json:"request"`
+	Sdk             map[string]interface{} `json:"sdk"`
+	Version         string                 `json:"version"`
 }
 
 func (e *Error) eventId() {

--- a/error.go
+++ b/error.go
@@ -42,8 +42,7 @@ type Error struct {
 	Request         map[string]interface{} `json:"request"`
 	Sdk             map[string]interface{} `json:"sdk"`
 	Version         string                 `json:"version"`
-
-	// TODO extra (additional information)
+	Extra           map[string]interface{} `json:"extra"`
 }
 
 func (e *Error) eventId() {

--- a/error.go
+++ b/error.go
@@ -10,13 +10,35 @@ import (
 	"github.com/shopspring/decimal"
 )
 
+/*
+Post-Ingestion from https://sentry.io/api/0/projects/<org>/<project>/events/<event_id>/json/
+skip _meta, _metrics, errors
+*/
 type Error struct {
 	EventId   string                 `json:"event_id"`
 	Release   string                 `json:"release"`
 	User      map[string]interface{} `json:"user"`
 	Timestamp float64                `json:"timestamp"`
-	// Type      string                 `json:"type"`
-	Platform string `json:"platform"`
+	Type      string                 `json:"type"`
+	Platform  string                 `json:"platform"`
+
+	Project int `json:"project"`
+	// Dist     string `json:"dist"`
+	Message string `json:"message"`
+	// Datetime string `json:"datetime"`
+	Tags            [][]string             `json:"tags"`
+	Breadcrumbs     map[string]interface{} `json:"breadcrumbs"`
+	Contexts        map[string]interface{} `json:"contexts"`
+	Culprit         string                 `json:"culprit"`
+	Environment     string                 `json:"environment"`
+	Exception       map[string]interface{} `json:"exception"`
+	Fingerprint     []string               `json:"fingerprint"`     // nothing new but also no processing error warnings
+	Grouping_config map[string]interface{} `json:"grouping_config"` // nothing new but also no processing error warnings
+	Hashes          []string               `json:"hashes"`          // nothing new but also no processing error warnings
+	Key_id          string                 `json:"key_id"`
+	Level           string                 `json:"level"`
+	Location        string                 `json:"location"`
+	Logger          string                 `json:"logger"`
 }
 
 func (e *Error) eventId() {

--- a/error.go
+++ b/error.go
@@ -13,7 +13,7 @@ import (
 /*
 Post-Ingestion from https://sentry.io/api/0/projects/<org>/<project>/events/<event_id>/json/
 Either don't sound needed or give 'Discarded unknown attribute'
-skip _meta, _metrics, errors, location, title
+skip: dist, datetime, _meta, _metrics, errors, location, title
 */
 type Error struct {
 	EventId   string                 `json:"event_id"`
@@ -23,10 +23,8 @@ type Error struct {
 	Type      string                 `json:"type"`
 	Platform  string                 `json:"platform"`
 
-	Project int `json:"project"`
-	// Dist     string `json:"dist"`
-	Message string `json:"message"`
-	// Datetime string `json:"datetime"`
+	Project         int                    `json:"project"`
+	Message         string                 `json:"message"`
 	Tags            [][]string             `json:"tags"`
 	Breadcrumbs     map[string]interface{} `json:"breadcrumbs"`
 	Contexts        map[string]interface{} `json:"contexts"`

--- a/error.go
+++ b/error.go
@@ -19,18 +19,16 @@ type Error struct {
 	Platform string `json:"platform"`
 }
 
-func (e Error) eventId() Error {
+func (e *Error) eventId() {
 	// if _, ok := e.EventId; !ok {
 	// 	log.Print("no event_id on object from DB")
 	// }
 	var uuid4 = strings.ReplaceAll(uuid.New().String(), "-", "")
 	e.EventId = uuid4
-	// fmt.Println("\n> event_id updated", e.EventId)
-	return e
 }
 
 // CalVer https://calver.org/
-func (e Error) release() Error {
+func (e *Error) release() {
 	date := time.Now()
 	month := date.Month()
 	day := date.Day()
@@ -47,17 +45,15 @@ func (e Error) release() Error {
 	}
 	release := fmt.Sprint(int(month), ".", week)
 	e.Release = release
-	return e
 }
 
-func (e Error) user() Error {
+func (e *Error) user() {
 	e.User = make(map[string]interface{})
 	user := e.User //.(map[string]interface{})
 	user["email"] = createUser()
-	return e
 }
 
-func (e Error) setTimestamp() Error {
+func (e *Error) setTimestamp() {
 	timestamp := fmt.Sprint(time.Now().Unix())
 	timestampDecimal, err1 := decimal.NewFromString(timestamp[:10] + "." + timestamp[10:])
 	fmt.Print("> timestampDecimal\n", timestampDecimal)
@@ -69,5 +65,4 @@ func (e Error) setTimestamp() Error {
 		log.Fatal(err2)
 	}
 	e.Timestamp = timestampFinal
-	return e
 }

--- a/error.go
+++ b/error.go
@@ -78,7 +78,7 @@ func (e *Error) user() {
 	user["email"] = createUser()
 }
 
-func (e *Error) setTimestamp() {
+func (e *Error) timestamp() {
 	timestamp := fmt.Sprint(time.Now().Unix())
 	timestampDecimal, err1 := decimal.NewFromString(timestamp[:10] + "." + timestamp[10:])
 	// fmt.Print("> timestampDecimal\n", timestampDecimal)

--- a/error.go
+++ b/error.go
@@ -16,6 +16,7 @@ type Error struct {
 	User      map[string]interface{} `json:"user"`
 	Timestamp float64                `json:"timestamp"`
 	// Type      string                 `json:"type"`
+	Platform string `json:"platform"`
 }
 
 func (e Error) eventId() Error {

--- a/error.go
+++ b/error.go
@@ -81,7 +81,7 @@ func (e *Error) user() {
 func (e *Error) setTimestamp() {
 	timestamp := fmt.Sprint(time.Now().Unix())
 	timestampDecimal, err1 := decimal.NewFromString(timestamp[:10] + "." + timestamp[10:])
-	fmt.Print("> timestampDecimal\n", timestampDecimal)
+	// fmt.Print("> timestampDecimal\n", timestampDecimal)
 	if err1 != nil {
 		log.Fatal(err1)
 	}

--- a/error.go
+++ b/error.go
@@ -60,7 +60,7 @@ func (e Error) user() Error {
 func (e Error) setTimestamp() Error {
 	timestamp := fmt.Sprint(time.Now().Unix())
 	timestampDecimal, err1 := decimal.NewFromString(timestamp[:10] + "." + timestamp[10:])
-	fmt.Print("> timestampDecimal", timestampDecimal)
+	fmt.Print("> timestampDecimal\n", timestampDecimal)
 	if err1 != nil {
 		log.Fatal(err1)
 	}

--- a/error.go
+++ b/error.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Error struct {
+	EventId   string                 `json:"event_id"`
+	Release   string                 `json:"release"`
+	User      map[string]interface{} `json:"user"`
+	Timestamp int64                  `json:"timestamp"`
+	// Type      string                 `json:"type"`
+}
+
+func (e Error) eventId() Error {
+	// if _, ok := e.EventId; !ok {
+	// 	log.Print("no event_id on object from DB")
+	// }
+	var uuid4 = strings.ReplaceAll(uuid.New().String(), "-", "")
+	e.EventId = uuid4
+	fmt.Println("\n> event_id updated", e.EventId)
+	return e
+}
+
+// CalVer https://calver.org/
+func (e Error) release() Error {
+	date := time.Now()
+	month := date.Month()
+	day := date.Day()
+	var week int
+	switch {
+	case day <= 7:
+		week = 1
+	case day >= 8 && day <= 14:
+		week = 2
+	case day >= 15 && day <= 21:
+		week = 3
+	case day >= 22:
+		week = 4
+	}
+	release := fmt.Sprint(int(month), ".", week)
+	e.Release = release
+	return e
+}
+
+func (e Error) user() Error {
+	e.User = make(map[string]interface{})
+	user := e.User //.(map[string]interface{})
+	user["email"] = createUser()
+	return e
+}
+
+func (e Error) setTimestamp() Error {
+	e.Timestamp = time.Now().Unix()
+	return e
+}

--- a/error.go
+++ b/error.go
@@ -42,6 +42,8 @@ type Error struct {
 	Request         map[string]interface{} `json:"request"`
 	Sdk             map[string]interface{} `json:"sdk"`
 	Version         string                 `json:"version"`
+
+	// TODO extra (additional information)
 }
 
 func (e *Error) eventId() {
@@ -79,15 +81,15 @@ func (e *Error) user() {
 }
 
 func (e *Error) timestamp() {
-	timestamp := fmt.Sprint(time.Now().Unix())
-	timestampDecimal, err1 := decimal.NewFromString(timestamp[:10] + "." + timestamp[10:])
-	// fmt.Print("> timestampDecimal\n", timestampDecimal)
+	unixTimestamp := fmt.Sprint(time.Now().Unix())
+	decimalTimestamp, err1 := decimal.NewFromString(unixTimestamp[:10] + "." + unixTimestamp[10:])
+	// fmt.Print("> decimalTimestamp\n", decimalTimestamp)
 	if err1 != nil {
 		log.Fatal(err1)
 	}
-	timestampFinal, err2 := timestampDecimal.Round(7).Float64()
+	timestamp, err2 := decimalTimestamp.Round(7).Float64()
 	if err2 == false {
 		log.Fatal(err2)
 	}
-	e.Timestamp = timestampFinal
+	e.Timestamp = timestamp
 }

--- a/error.go
+++ b/error.go
@@ -2,17 +2,19 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
 )
 
 type Error struct {
 	EventId   string                 `json:"event_id"`
 	Release   string                 `json:"release"`
 	User      map[string]interface{} `json:"user"`
-	Timestamp int64                  `json:"timestamp"`
+	Timestamp float64                `json:"timestamp"`
 	// Type      string                 `json:"type"`
 }
 
@@ -22,7 +24,7 @@ func (e Error) eventId() Error {
 	// }
 	var uuid4 = strings.ReplaceAll(uuid.New().String(), "-", "")
 	e.EventId = uuid4
-	fmt.Println("\n> event_id updated", e.EventId)
+	// fmt.Println("\n> event_id updated", e.EventId)
 	return e
 }
 
@@ -55,6 +57,16 @@ func (e Error) user() Error {
 }
 
 func (e Error) setTimestamp() Error {
-	e.Timestamp = time.Now().Unix()
+	timestamp := fmt.Sprint(time.Now().Unix())
+	timestampDecimal, err1 := decimal.NewFromString(timestamp[:10] + "." + timestamp[10:])
+	fmt.Print("> timestampDecimal", timestampDecimal)
+	if err1 != nil {
+		log.Fatal(err1)
+	}
+	timestampFinal, err2 := timestampDecimal.Round(7).Float64()
+	if err2 == false {
+		log.Fatal(err2)
+	}
+	e.Timestamp = timestampFinal
 	return e
 }

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -121,7 +121,7 @@ type EventJson struct {
 	EventId   string                 `json:"event_id"`
 	Release   string                 `json:"release"`
 	User      map[string]interface{} `json:"user"`
-	Timestamp string                 `json:"timestamp"`
+	Timestamp int64                  `json:"timestamp"` // not float64?
 	Type      string                 `json:"type"`
 }
 type Event struct {

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -118,7 +118,7 @@ func (d DSN) envelopeEndpoint() string {
 }
 
 type EventJson struct {
-	eventId string `json:"eventId"`
+	EventId string `json:"event_id"`
 }
 type Event struct {
 	Platform string            `json:"platform"`

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -186,31 +186,31 @@ type Timestamp struct {
 	rfc3339 bool
 }
 
-type Item struct {
-	Timestamp Timestamp `json:"timestamp,omitempty"`
-	// Timestamp time.Time `json:"timestamp,omitempty"`
+// type Item struct {
+// 	Timestamp Timestamp `json:"timestamp,omitempty"`
+// 	// Timestamp time.Time `json:"timestamp,omitempty"`
 
-	Event_id string `json:"event_id,omitempty"`
-	Sent_at  string `json:"sent_at,omitempty"`
+// 	Event_id string `json:"event_id,omitempty"`
+// 	Sent_at  string `json:"sent_at,omitempty"`
 
-	Length       int    `json:"length,omitempty"`
-	Type         string `json:"type,omitempty"`
-	Content_type string `json:"content_type,omitempty"`
+// 	Length       int    `json:"length,omitempty"`
+// 	Type         string `json:"type,omitempty"`
+// 	Content_type string `json:"content_type,omitempty"`
 
-	Start_timestamp string                 `json:"start_timestamp,omitempty"`
-	Transaction     string                 `json:"transaction,omitempty"`
-	Server_name     string                 `json:"server_name,omitempty"`
-	Tags            map[string]interface{} `json:"tags,omitempty"`
-	Contexts        map[string]interface{} `json:"contexts,omitempty"`
+// 	Start_timestamp string                 `json:"start_timestamp,omitempty"`
+// 	Transaction     string                 `json:"transaction,omitempty"`
+// 	Server_name     string                 `json:"server_name,omitempty"`
+// 	Tags            map[string]interface{} `json:"tags,omitempty"`
+// 	Contexts        map[string]interface{} `json:"contexts,omitempty"`
 
-	Extra       map[string]interface{} `json:"extra,omitempty"`
-	Request     map[string]interface{} `json:"request,omitempty"`
-	Environment string                 `json:"environment,omitempty"`
-	Platform    string                 `json:"platform,omitempty"`
-	// Todo spans []
-	Sdk  map[string]interface{} `json:"sdk,omitempty"`
-	User map[string]interface{} `json:"user,omitempty"`
-}
+// 	Extra       map[string]interface{} `json:"extra,omitempty"`
+// 	Request     map[string]interface{} `json:"request,omitempty"`
+// 	Environment string                 `json:"environment,omitempty"`
+// 	Platform    string                 `json:"platform,omitempty"`
+// 	// Todo spans []
+// 	Sdk  map[string]interface{} `json:"sdk,omitempty"`
+// 	User map[string]interface{} `json:"user,omitempty"`
+// }
 
 // TODO need an ItemFinal that has unified timestamp?
 

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -140,14 +140,12 @@ func (eventJson *EventJson) UnmarshalJSON(data []byte) error {
 	switch eventJson.Kind {
 	case "error":
 		eventJson.Error = &Error{}
-		fmt.Println(">>> ERROR")
 		return json.Unmarshal(data, eventJson.Error)
 	case "transaction":
-		fmt.Println(">>> TRANSACTION")
 		eventJson.Transaction = &Transaction{}
 		return json.Unmarshal(data, eventJson.Transaction)
 	default:
-		return fmt.Errorf("unrecognized type value %q", eventJson.Type)
+		return fmt.Errorf("unrecognized type value %q", eventJson.Kind)
 	}
 }
 

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -94,6 +94,7 @@ func (d DSN) storeEndpoint() string {
 	if strings.Contains(d.host, "ingest.sentry.io") {
 		// TODO [1:] is for removing leading slash from sentry_key=/a971db611df44a6eaf8993d994db1996, which errors ""bad sentry DSN public key""
 		fullurl = fmt.Sprint("https://", d.host, "/api/", d.projectId, "/store/?sentry_key=", d.key[1:], "&sentry_version=7")
+		// fullurl = fmt.Sprint("https://", d.host, "/api/", d.projectId, "/store/?sentry_key=", d.key[1:])
 	}
 	if d.host == "localhost:9000" {
 		fullurl = fmt.Sprint("http://", d.host, "/api/", d.projectId, "/store/?sentry_key=", d.key, "&sentry_version=7")
@@ -253,7 +254,7 @@ func main() {
 	// 	log.Fatal(err)
 	// }
 
-	readJsons()
+	readJsons(*ignore)
 	return
 
 	// CLOUD STORAGE

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -113,16 +113,11 @@ func (d DSN) envelopeEndpoint() string {
 	return fullurl
 }
 
-// TODO put EventJson to its own eventjson.go already!
+// TODO put EventJson to its own eventjson.go
 type TypeSwitch struct {
 	Kind string `json:"type"`
 }
 type EventJson struct {
-	// EventId    string                 `json:"event_id"`
-	// Release    string                 `json:"release"`
-	// User       map[string]interface{} `json:"user"`
-	// Timestamp  float64                `json:"timestamp"`
-	// Platform   string                 `json:"platform"`
 	TypeSwitch `json:"type"`
 	*Error
 	*Transaction
@@ -143,22 +138,6 @@ func (eventJson *EventJson) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("unrecognized type value %q", eventJson.Kind)
 	}
 }
-
-// DONT NEED ANYMORE?
-// func (eventJson *EventJson) send() error {
-// TODO make a Request using event and `dsnToStoreEndpoint(projectDSNs, event.Error.Platform)``,
-// Kine -> error
-// event.Error in the Request...
-// Kind -> transaction
-// event.Transaction in the Request
-
-// request = Request{
-// 	EventJson:     event,
-// 	storeEndpoint: dsnToStoreEndpoint(projectDSNs, event.Error.Platform),
-// })
-
-// request.send()
-// }
 
 type Event struct {
 	Platform string            `json:"platform"`
@@ -208,52 +187,15 @@ func matchDSN(projectDSNs map[string]*DSN, event Event) string {
 	return storeEndpoint
 }
 
-// type Envelope struct {
-// 	items []interface{}
-// }
-
-// type Item map[string]interface{}
-
-// type Timestamp time.Time
 type Timestamp struct {
 	time.Time
 	rfc3339 bool
 }
 
-// type Item struct {
-// 	Timestamp Timestamp `json:"timestamp,omitempty"`
-// 	// Timestamp time.Time `json:"timestamp,omitempty"`
-
-// 	Event_id string `json:"event_id,omitempty"`
-// 	Sent_at  string `json:"sent_at,omitempty"`
-
-// 	Length       int    `json:"length,omitempty"`
-// 	Type         string `json:"type,omitempty"`
-// 	Content_type string `json:"content_type,omitempty"`
-
-// 	Start_timestamp string                 `json:"start_timestamp,omitempty"`
-// 	Transaction     string                 `json:"transaction,omitempty"`
-// 	Server_name     string                 `json:"server_name,omitempty"`
-// 	Tags            map[string]interface{} `json:"tags,omitempty"`
-// 	Contexts        map[string]interface{} `json:"contexts,omitempty"`
-
-// 	Extra       map[string]interface{} `json:"extra,omitempty"`
-// 	Request     map[string]interface{} `json:"request,omitempty"`
-// 	Environment string                 `json:"environment,omitempty"`
-// 	Platform    string                 `json:"platform,omitempty"`
-// 	// Todo spans []
-// 	Sdk  map[string]interface{} `json:"sdk,omitempty"`
-// 	User map[string]interface{} `json:"user,omitempty"`
-// }
-
-// TODO need an ItemFinal that has unified timestamp?
-
 func init() {
 	if err := godotenv.Load(); err != nil {
 		log.Print("No .env file found")
 	}
-
-	//traceIdMap = make(map[string][]interface{})
 
 	all = flag.Bool("all", false, "send all events. default is send latest event")
 	id = flag.String("id", "", "id of event in sqlite database") // 08/27 non-functional today

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -123,6 +123,7 @@ type EventJson struct {
 	User      map[string]interface{} `json:"user"`
 	Timestamp float64                `json:"timestamp"`
 	Type      string                 `json:"type"`
+	Platform  string                 `json:"platform"`
 }
 type Event struct {
 	Platform string            `json:"platform"`
@@ -134,7 +135,17 @@ type Event struct {
 func (e Event) String() string {
 	return fmt.Sprintf("\n Event { Platform: %s, Type: %s }\n", e.Platform, e.Kind) // index somehow?
 }
-
+func findDSN(projectDSNs map[string]*DSN, platform string) string {
+	// var storeEndpoint string
+	if platform == "javascript" {
+		return projectDSNs["javascript"].storeEndpoint()
+	} else if platform == "python" {
+		return projectDSNs["python"].storeEndpoint()
+	} else {
+		log.Fatal("platform type not supported")
+	}
+	return ""
+}
 func matchDSN(projectDSNs map[string]*DSN, event Event) string {
 
 	platform := event.Platform
@@ -287,8 +298,9 @@ func main() {
 				platform:      event.Platform,
 				eventHeaders:  event.Headers,
 				storeEndpoint: storeEndpoint,
-				bodyError:     bodyError,
-				bodyEncoder:   bodyEncoder,
+
+				bodyError:   bodyError,
+				bodyEncoder: bodyEncoder,
 			})
 
 		} else if event.Kind == "transaction" {
@@ -302,10 +314,11 @@ func main() {
 			getEnvelopeTraceIds(envelopeItems)
 
 			requests = append(requests, Transport{
-				kind:            event.Kind,
-				platform:        event.Platform,
-				eventHeaders:    event.Headers,
-				storeEndpoint:   storeEndpoint,
+				kind:          event.Kind,
+				platform:      event.Platform,
+				eventHeaders:  event.Headers,
+				storeEndpoint: storeEndpoint,
+
 				envelopeItems:   envelopeItems,
 				envelopeEncoder: envelopeEncoder,
 			})

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -117,6 +117,9 @@ func (d DSN) envelopeEndpoint() string {
 	return fullurl
 }
 
+type EventJson struct {
+	eventId string `json:"eventId"`
+}
 type Event struct {
 	Platform string            `json:"platform"`
 	Kind     string            `json:"kind"`
@@ -234,6 +237,9 @@ func main() {
 	// if err != nil {
 	// 	log.Fatal(err)
 	// }
+
+	readJsons()
+	return
 
 	// CLOUD STORAGE
 	bucket := os.Getenv("BUCKET")

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -118,7 +118,11 @@ func (d DSN) envelopeEndpoint() string {
 }
 
 type EventJson struct {
-	EventId string `json:"event_id"`
+	EventId   string                 `json:"event_id"`
+	Release   string                 `json:"release"`
+	User      map[string]interface{} `json:"user"`
+	Timestamp string                 `json:"timestamp"`
+	Type      string                 `json:"type"`
 }
 type Event struct {
 	Platform string            `json:"platform"`

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -32,12 +32,7 @@ var (
 	SENTRY_URL  string
 	exists      bool
 	projectDSNs map[string]*DSN
-	// traceIdMap0 map[string][]*Item
-	//traceIdMap map[string][]interface{}
-	traceIds []string
-
-	// traceIdMap2 map[string][]string
-	// traceIdMap := map[string][]*interface{}
+	traceIds    []string
 )
 
 type DSN struct {

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -237,7 +237,7 @@ func main() {
 
 	// CLOUD STORAGE
 	bucket := os.Getenv("BUCKET")
-	object := "npm-sentry-tracing.json"
+	object := database
 	fmt.Println("DATASET object", object)
 	ctx := context.Background()
 	client, err := storage.NewClient(ctx)

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -135,7 +135,7 @@ type Event struct {
 func (e Event) String() string {
 	return fmt.Sprintf("\n Event { Platform: %s, Type: %s }\n", e.Platform, e.Kind) // index somehow?
 }
-func findDSN(projectDSNs map[string]*DSN, platform string) string {
+func dsnToStoreEndpoint(projectDSNs map[string]*DSN, platform string) string {
 	// var storeEndpoint string
 	if platform == "javascript" {
 		return projectDSNs["javascript"].storeEndpoint()

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -121,7 +121,7 @@ type EventJson struct {
 	EventId   string                 `json:"event_id"`
 	Release   string                 `json:"release"`
 	User      map[string]interface{} `json:"user"`
-	Timestamp int64                  `json:"timestamp"` // not float64?
+	Timestamp float64                `json:"timestamp"`
 	Type      string                 `json:"type"`
 }
 type Event struct {

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -118,6 +118,7 @@ func (d DSN) envelopeEndpoint() string {
 	return fullurl
 }
 
+// TODO put EventJson to its own eventjson.go already!
 type TypeSwitch struct {
 	Kind string `json:"type"`
 }
@@ -130,9 +131,6 @@ type EventJson struct {
 	TypeSwitch `json:"type"`
 	*Error
 	*Transaction
-
-	// TODO 6:12p YES so can call request.send()
-	// *Request
 }
 
 func (eventJson *EventJson) UnmarshalJSON(data []byte) error {
@@ -153,21 +151,21 @@ func (eventJson *EventJson) UnmarshalJSON(data []byte) error {
 	}
 }
 
-func (eventJson *EventJson) send() error {
-	// TODO make a Request using event and `dsnToStoreEndpoint(projectDSNs, event.Error.Platform)``,
-	// Kine -> error
-	// event.Error in the Request...
-	// Kind -> transaction
-	// event.Transaction in the Request
+// DONT NEED ANYMORE?
+// func (eventJson *EventJson) send() error {
+// TODO make a Request using event and `dsnToStoreEndpoint(projectDSNs, event.Error.Platform)``,
+// Kine -> error
+// event.Error in the Request...
+// Kind -> transaction
+// event.Transaction in the Request
 
-	// request = Request{
-	// 	EventJson:     event,
-	// 	storeEndpoint: dsnToStoreEndpoint(projectDSNs, event.Error.Platform),
-	// })
+// request = Request{
+// 	EventJson:     event,
+// 	storeEndpoint: dsnToStoreEndpoint(projectDSNs, event.Error.Platform),
+// })
 
-	// request.send()
-
-}
+// request.send()
+// }
 
 type Event struct {
 	Platform string            `json:"platform"`

--- a/event-to-sentry.go
+++ b/event-to-sentry.go
@@ -130,6 +130,9 @@ type EventJson struct {
 	TypeSwitch `json:"type"`
 	*Error
 	*Transaction
+
+	// TODO 6:12p YES so can call request.send()
+	// *Request
 }
 
 func (eventJson *EventJson) UnmarshalJSON(data []byte) error {
@@ -150,6 +153,22 @@ func (eventJson *EventJson) UnmarshalJSON(data []byte) error {
 	}
 }
 
+func (eventJson *EventJson) send() error {
+	// TODO make a Request using event and `dsnToStoreEndpoint(projectDSNs, event.Error.Platform)``,
+	// Kine -> error
+	// event.Error in the Request...
+	// Kind -> transaction
+	// event.Transaction in the Request
+
+	// request = Request{
+	// 	EventJson:     event,
+	// 	storeEndpoint: dsnToStoreEndpoint(projectDSNs, event.Error.Platform),
+	// })
+
+	// request.send()
+
+}
+
 type Event struct {
 	Platform string            `json:"platform"`
 	Kind     string            `json:"kind"`
@@ -160,11 +179,11 @@ type Event struct {
 func (e Event) String() string {
 	return fmt.Sprintf("\n Event { Platform: %s, Type: %s }\n", e.Platform, e.Kind) // index somehow?
 }
-func dsnToStoreEndpoint(projectDSNs map[string]*DSN, platform string) string {
+func dsnToStoreEndpoint(projectDSNs map[string]*DSN, projectPlatform string) string {
 	// var storeEndpoint string
-	if platform == "javascript" {
+	if projectPlatform == "javascript" {
 		return projectDSNs["javascript"].storeEndpoint()
-	} else if platform == "python" {
+	} else if projectPlatform == "python" {
 		return projectDSNs["python"].storeEndpoint()
 	} else {
 		log.Fatal("platform type not supported")

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de // indirect
 	golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1 // indirect
 	golang.org/x/tools v0.0.0-20200731060945-b5fad4ed8dd6 // indirect
+	google.golang.org/api v0.29.0
 	google.golang.org/appengine v1.6.6 // indirect
 	google.golang.org/genproto v0.0.0-20200731012542-8145dea6a485 // indirect
 	google.golang.org/grpc v1.31.0 // indirect

--- a/python/proxy.py
+++ b/python/proxy.py
@@ -179,10 +179,10 @@ def save_envelope():
         for key in ['Accept-Encoding','Content-Length','Content-Type','User-Agent']:
             request_headers[key] = request.headers.get(key)
         body = request.data.decode("utf-8")
-
+    
     print(type(json.dumps(body)))
-
-    o = {
+    
+    event = {
         'platform': event_platform,
         'kind': event_type,
         'headers': request_headers,
@@ -193,11 +193,14 @@ def save_envelope():
         with open(JSON) as file:
             current_data = json.load(file)
         with open(JSON, 'w') as file:
-            current_data.append(o)
+            current_data.append(event)
             json.dump(current_data, file)
 
     except Exception as exception:
         print("LOCAL EXCEPTION", exception)
+        print("LOCAL EXCEPTION event_platform:", event_platform)
+        print("LOCAL EXCEPTION event_type:", event_type)
+        
     return "success"
 
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -3,4 +3,4 @@ flask_cors==3.0.8
 psycopg2-binary==2.8.4
 python-dotenv==0.12.0
 requests==2.18.4
-sentry-sdk==0.14.2
+sentry-sdk==0.19.2

--- a/python/services.py
+++ b/python/services.py
@@ -31,11 +31,9 @@ def compress_gzip(dict_body):
 def get_event_type(payload, platform):
     body_dict = ''
     if platform == 'python':
-        print('\n****** PYTHON ')
         body_dict = decompress_gzip(payload)
         # body_dict = json.loads(decompress_gzip(payload))
     if platform == 'javascript':
-        print('\n****** JAVASCRIPT ')
         envelope = payload
         print('type(envelope) ist still bytes, so decode it', type(envelope))
 

--- a/read-jsons.go
+++ b/read-jsons.go
@@ -19,7 +19,6 @@ https://github.com/GoogleCloudPlatform/golang-samples/blob/8deb2909eadf32523007f
 */
 func readJsons(ignore bool) string {
 	bucketName := os.Getenv("BUCKET")
-
 	// Initialize/Connect the Client
 	ctx := context.Background()
 	client, err := storage.NewClient(ctx)
@@ -29,10 +28,8 @@ func readJsons(ignore bool) string {
 	defer client.Close()
 	ctx, cancel := context.WithTimeout(ctx, time.Second*50)
 	defer cancel()
-
 	// Prepare bucket handle
 	bucketHandle := client.Bucket(bucketName)
-
 	// lists the contents of a bucket in Google Cloud Storage.
 	var fileNames []string
 	query := &storage.Query{Prefix: "event"}
@@ -63,37 +60,35 @@ func readJsons(ignore bool) string {
 		if err := json.Unmarshal(byteValue, &event); err != nil { // TODO float64 vs int64
 			panic(err)
 		}
-		fmt.Printf("\n> > > > > > >  EVENT > > > >  %+v \n", event)
+		// fmt.Printf("\n> > > > > > >  EVENT > > > >  %+v \n", event)
 		events = append(events, event)
 	}
 
 	requests := []Request{}
 
 	for _, event := range events {
-		// TODO match DSN based on js vs python, call on EventJson?
-		if event.Type == "error" {
-			fmt.Println("> error")
-			eventError := Error{event.EventId, event.Release, event.User, event.Timestamp, event.Platform}
+		// TODO match DSN here based on js vs python, call on EventJson?
+		if event.Kind == "error" {
+			fmt.Println("> error <")
+			// eventError := Error{event.EventId, event.Release, event.User, event.Timestamp, event.Platform}
 
-			fmt.Println("\n> event_id BEFORE", eventError.EventId)
-			eventError.eventId()
-			fmt.Println("\n> event_id AFTER", eventError.EventId)
-
-			// eventError.release()
-			// eventError.user()
-
-			fmt.Println("\n> timestamp BEFORE", eventError.Timestamp)
-			eventError.setTimestamp()
-			fmt.Println("\n> timestamp AFTER", eventError.Timestamp)
+			fmt.Println("\n> event_id BEFORE", event.Error.EventId)
+			fmt.Println("\n> timestamp BEFORE", event.Error.Timestamp)
+			event.Error.eventId()
+			event.Error.release()
+			event.Error.user()
+			event.Error.setTimestamp()
+			fmt.Println("\n> event_id AFTER", event.Error.EventId)
+			fmt.Println("\n> timestamp AFTER", event.Error.Timestamp)
 
 			requests = append(requests, Request{
-				errorPayload:  eventError,
-				storeEndpoint: dsnToStoreEndpoint(projectDSNs, eventError.Platform),
+				EventJson:     event,
+				storeEndpoint: dsnToStoreEndpoint(projectDSNs, event.Error.Platform),
 				// sentryAuthKey:
 			})
 		}
-		if event.Type == "transaction" {
-			fmt.Println("> transaction")
+		if event.Kind == "transaction" {
+			fmt.Println("> transaction <")
 			// eventTransaction := Transaction{event.EventId, event.Release, event.User, event.Timestamp}
 			// eventTransaction.eventIds()
 			// eventTransaction.setReleases()

--- a/read-jsons.go
+++ b/read-jsons.go
@@ -80,33 +80,21 @@ func readJsons(ignore bool) string {
 		if event.Kind == "transaction" {
 			fmt.Println("> transaction <")
 
-			// TODO 11:23a****** MAY SOLVE IT!!!!
 			event.Transaction.eventId()
+			event.Transaction.release()
+			event.Transaction.user()
 
-			// event.Transaction.setReleases()
-			// event.Transaction.setUsers()
+			// TODO
 			// event.Transaction.setTimestamps()
-
-			// event.Transaction.sentAt()
-			// event.Transaction.removeLengthField()
-
-			// requests = append(requests, Request{
-			// 	EventJson:     event,
-			// 	storeEndpoint: dsnToStoreEndpoint(projectDSNs, event.Error.Platform),
-			// })
 		}
-
-		// TODO can run once here `requests = append(requests, Request{` instead of inside Error as well as Transaction if-then block
 	}
-
-	// i.e. put the 'Request' as an embedded struct type on the EventJson ;)??
 
 	// TODO double check it's object was updated reference `fmt.Println("\n> timestamp AFTER", event.Error.Timestamp)`
 	requests := Requests{events}
 	requests.send()
 
 	return "\n DONE \n"
-	// sendRequests(requests, ignore) // deprecate
+
 }
 
 func printObj(obj *storage.ObjectAttrs) {
@@ -122,3 +110,10 @@ func printObj(obj *storage.ObjectAttrs) {
 	// fmt.Printf("MediaLink: %q, ", obj.MediaLink)
 	// fmt.Printf("StorageClass: %q, ", obj.StorageClass)
 }
+
+// sendRequests(requests, ignore) // deprecate
+
+// requests = append(requests, Request{
+// 	EventJson:     event,
+// 	storeEndpoint: dsnToStoreEndpoint(projectDSNs, event.Error.Platform),
+// })

--- a/read-jsons.go
+++ b/read-jsons.go
@@ -75,7 +75,7 @@ func readJsons(ignore bool) string {
 	for _, event := range events {
 		// TODO match DSN here based on js vs python, call on EventJson?
 		if event.Kind == "error" {
-			fmt.Println("> error <")
+			// fmt.Println("> error <")
 			// fmt.Println("\n> event_id BEFORE", event.Error.EventId)
 			// fmt.Println("\n> timestamp BEFORE", event.Error.Timestamp)
 			event.Error.eventId()
@@ -86,13 +86,13 @@ func readJsons(ignore bool) string {
 			// fmt.Println("\n> timestamp AFTER", event.Error.Timestamp)
 		}
 		if event.Kind == "transaction" {
-			fmt.Println("> transaction <")
+			fmt.Println("\n> transaction <")
 
 			event.Transaction.eventId()
 			event.Transaction.release()
 			event.Transaction.user()
 			event.Transaction.timestamps()
-			event.Transaction.traceIds()
+			// event.Transaction.traceIds()
 		}
 	}
 

--- a/read-jsons.go
+++ b/read-jsons.go
@@ -17,9 +17,7 @@ import (
 https://cloud.google.com/appengine/docs/standard/go111/googlecloudstorageclient/read-write-to-cloud-storage
 https://github.com/GoogleCloudPlatform/golang-samples/blob/8deb2909eadf32523007fd8fe9e8755a12c6d463/docs/appengine/storage/app.go
 */
-func readJsons() string {
-	fmt.Println("This is a readJsons test...")
-
+func readJsons(ignore bool) string {
 	bucketName := os.Getenv("BUCKET")
 
 	// Initialize/Connect the Client
@@ -65,11 +63,9 @@ func readJsons() string {
 		if err := json.Unmarshal(byteValue, &event); err != nil { // TODO float64 vs int64
 			panic(err)
 		}
-
+		fmt.Printf("\n> > > > > > >  EVENT > > > >  %+v \n", event)
 		events = append(events, event)
 	}
-
-	// fmt.Println(">>>>> events []EventJson", len(events))
 
 	requests := []Request{}
 
@@ -78,15 +74,22 @@ func readJsons() string {
 		if event.Type == "error" {
 			fmt.Println("> error")
 			eventError := Error{event.EventId, event.Release, event.User, event.Timestamp, event.Platform}
-			eventError.eventId()
-			eventError.release()
-			eventError.user()
-			eventError.setTimestamp()
 
-			// storeEndpoint := findDSN(projectDSNs, eventError.Platform)
+			fmt.Println("\n> event_id BEFORE", eventError.EventId)
+			eventError.eventId()
+			fmt.Println("\n> event_id AFTER", eventError.EventId)
+
+			// eventError.release()
+			// eventError.user()
+
+			fmt.Println("\n> timestamp BEFORE", eventError.Timestamp)
+			eventError.setTimestamp()
+			fmt.Println("\n> timestamp AFTER", eventError.Timestamp)
+
 			requests = append(requests, Request{
 				errorPayload:  eventError,
 				storeEndpoint: dsnToStoreEndpoint(projectDSNs, eventError.Platform),
+				// sentryAuthKey:
 			})
 		}
 		if event.Type == "transaction" {
@@ -102,7 +105,7 @@ func readJsons() string {
 		}
 	}
 
-	sendRequests(requests)
+	sendRequests(requests, ignore)
 	return "\n DONE \n"
 }
 

--- a/read-jsons.go
+++ b/read-jsons.go
@@ -83,10 +83,10 @@ func readJsons() string {
 			eventError.user()
 			eventError.setTimestamp()
 
-			storeEndpoint := findDSN(projectDSNs, eventError.Platform)
+			// storeEndpoint := findDSN(projectDSNs, eventError.Platform)
 			requests = append(requests, Request{
 				errorPayload:  eventError,
-				storeEndpoint: storeEndpoint,
+				storeEndpoint: dsnToStoreEndpoint(projectDSNs, eventError.Platform),
 			})
 		}
 		if event.Type == "transaction" {

--- a/read-jsons.go
+++ b/read-jsons.go
@@ -96,6 +96,13 @@ func readJsons(ignore bool) string {
 		}
 	}
 
+	// TODO 8:13p
+	// events.traceIds ||
+	// mapTraceIds()
+	getTraceIds(events)
+	// events = setTraceIds(events, traceIds)
+	updateTraceIds(events)
+
 	// TODO double check it's object was updated reference `fmt.Println("\n> timestamp AFTER", event.Error.Timestamp)`
 	requests := Requests{events}
 	requests.send()

--- a/read-jsons.go
+++ b/read-jsons.go
@@ -66,24 +66,23 @@ func readJsons(ignore bool) string {
 		// TODO match DSN here based on js vs python, call on EventJson?
 		if event.Kind == "error" {
 			fmt.Println("> error <")
-			fmt.Println("\n> event_id BEFORE", event.Error.EventId)
-			fmt.Println("\n> timestamp BEFORE", event.Error.Timestamp)
+			// fmt.Println("\n> event_id BEFORE", event.Error.EventId)
+			// fmt.Println("\n> timestamp BEFORE", event.Error.Timestamp)
 
 			event.Error.eventId()
 			event.Error.release()
 			event.Error.user()
 			event.Error.setTimestamp()
 
-			fmt.Println("\n> event_id AFTER", event.Error.EventId)
-			fmt.Println("\n> timestamp AFTER", event.Error.Timestamp)
-			// requests = append(requests, Request{
-			// 	EventJson:     event,
-			// 	storeEndpoint: dsnToStoreEndpoint(projectDSNs, event.Error.Platform),
-			// })
+			// fmt.Println("\n> event_id AFTER", event.Error.EventId)
+			// fmt.Println("\n> timestamp AFTER", event.Error.Timestamp)
 		}
 		if event.Kind == "transaction" {
 			fmt.Println("> transaction <")
-			// event.Transaction.eventIds()
+
+			// TODO 11:23a****** MAY SOLVE IT!!!!
+			event.Transaction.eventId()
+
 			// event.Transaction.setReleases()
 			// event.Transaction.setUsers()
 			// event.Transaction.setTimestamps()

--- a/read-jsons.go
+++ b/read-jsons.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"time"
+
+	"cloud.google.com/go/storage"
+)
+
+func readJsons() string {
+	fmt.Println("This is a readJsons test...")
+
+	bucket := os.Getenv("BUCKET")
+
+	// Initialize/Connect the Client
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		log.Fatalln("storage.NewClient:", err)
+	}
+	defer client.Close()
+	ctx, cancel := context.WithTimeout(ctx, time.Second*50)
+	defer cancel()
+
+	// TODO
+	// 1 List all files for bucket...
+
+	// 2. iterate through each and add to global...
+
+	file := database
+	fmt.Println("DATASET file", file)
+	rc, err := client.Bucket(bucket).Object(file).NewReader(ctx)
+	if err != nil {
+		log.Fatalln("NewReader:", err)
+	}
+	byteValue, _ := ioutil.ReadAll(rc) // jsonFile
+	// defer jsonFile.Close()
+	events := make([]EventJson, 0)
+	if err := json.Unmarshal(byteValue, &events); err != nil {
+		panic(err)
+	}
+
+	return "read those jsons"
+}

--- a/read-jsons.go
+++ b/read-jsons.go
@@ -73,7 +73,23 @@ func readJsons() string {
 
 	fmt.Println(">>>>> events []EventJson", len(events))
 	for _, e := range events {
+		// match DSN based on js vs python
+		// decide Errors vs Transaction. if error.... make an Error struct. if transaction.... make a Transaction struct.... call methods on both
+		// if e.Type == "error" {
+
+		// }
+		// if e.Type == "transaction" {
+
+		// }
+
 		fmt.Println("> event.eventId", e.EventId)
+		// TODO
+		// assuming Error
+		// event = eventId(event) // would be error.eventId(), error.release(), error.user(), error.timestamp()
+		// event = release(event)
+		// event = user(event)
+		// event = updateTimestamp(event)
+
 	}
 
 	return "read those jsons"

--- a/read-jsons.go
+++ b/read-jsons.go
@@ -46,6 +46,16 @@ func readJsons(ignore bool) string {
 		printObj(obj)
 	}
 
+	// TODO events.go could manage reading from storage. or like:
+	/*
+		storageClient := StorageClient(os.Getenv("BUCKET")) <-- is the init
+		//or
+		storageClient.init(os.Getenv("BUCKET"))
+		storageClient.query("event") .prefixQuery("event") .queryBucket .bucketQuery() .bucketSet()
+		storageClient.listBucketContents() .getBucket()
+		events := storageClient.getFiles() .bucketFiles()
+	*/
+
 	// Read each file's content
 	var events []EventJson
 	for _, fileName := range fileNames {
@@ -68,12 +78,10 @@ func readJsons(ignore bool) string {
 			fmt.Println("> error <")
 			// fmt.Println("\n> event_id BEFORE", event.Error.EventId)
 			// fmt.Println("\n> timestamp BEFORE", event.Error.Timestamp)
-
 			event.Error.eventId()
 			event.Error.release()
 			event.Error.user()
-			event.Error.setTimestamp()
-
+			event.Error.timestamp()
 			// fmt.Println("\n> event_id AFTER", event.Error.EventId)
 			// fmt.Println("\n> timestamp AFTER", event.Error.Timestamp)
 		}
@@ -83,9 +91,8 @@ func readJsons(ignore bool) string {
 			event.Transaction.eventId()
 			event.Transaction.release()
 			event.Transaction.user()
-
-			// TODO
-			// event.Transaction.setTimestamps()
+			event.Transaction.timestamps()
+			event.Transaction.traceIds()
 		}
 	}
 

--- a/read-jsons.go
+++ b/read-jsons.go
@@ -32,7 +32,7 @@ func readJsons(ignore bool) string {
 	bucketHandle := client.Bucket(bucketName)
 	// lists the contents of a bucket in Google Cloud Storage.
 	var fileNames []string
-	query := &storage.Query{Prefix: "event"}
+	query := &storage.Query{Prefix: "eventtest"}
 	it := bucketHandle.Objects(ctx, query)
 	for {
 		obj, err := it.Next()
@@ -65,7 +65,7 @@ func readJsons(ignore bool) string {
 		}
 		byteValue, _ := ioutil.ReadAll(rc)
 		var event EventJson
-		// UnmarshalJSON overriden in error.go
+		// The EventJson's UnmarshalJSON overriden in event-to-sentry.go (soon EventJson.go)
 		if err := json.Unmarshal(byteValue, &event); err != nil {
 			panic(err)
 		}
@@ -73,34 +73,21 @@ func readJsons(ignore bool) string {
 	}
 
 	for _, event := range events {
-		// TODO match DSN here based on js vs python, call on EventJson?
 		if event.Kind == "error" {
-			// fmt.Println("> error <")
-			// fmt.Println("\n> event_id BEFORE", event.Error.EventId)
-			// fmt.Println("\n> timestamp BEFORE", event.Error.Timestamp)
 			event.Error.eventId()
 			event.Error.release()
 			event.Error.user()
 			event.Error.timestamp()
-			// fmt.Println("\n> event_id AFTER", event.Error.EventId)
-			// fmt.Println("\n> timestamp AFTER", event.Error.Timestamp)
 		}
 		if event.Kind == "transaction" {
-			fmt.Println("\n> transaction <")
-
 			event.Transaction.eventId()
 			event.Transaction.release()
 			event.Transaction.user()
 			event.Transaction.timestamps()
-			// event.Transaction.traceIds()
 		}
 	}
 
-	// TODO 8:13p
-	// events.traceIds ||
-	// mapTraceIds()
 	getTraceIds(events)
-	// events = setTraceIds(events, traceIds)
 	updateTraceIds(events)
 
 	// TODO double check it's object was updated reference `fmt.Println("\n> timestamp AFTER", event.Error.Timestamp)`
@@ -124,10 +111,3 @@ func printObj(obj *storage.ObjectAttrs) {
 	// fmt.Printf("MediaLink: %q, ", obj.MediaLink)
 	// fmt.Printf("StorageClass: %q, ", obj.StorageClass)
 }
-
-// sendRequests(requests, ignore) // deprecate
-
-// requests = append(requests, Request{
-// 	EventJson:     event,
-// 	storeEndpoint: dsnToStoreEndpoint(projectDSNs, event.Error.Platform),
-// })

--- a/read-jsons.go
+++ b/read-jsons.go
@@ -2,20 +2,23 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"time"
 
 	"cloud.google.com/go/storage"
+	"google.golang.org/api/iterator"
 )
 
+/*
+https://cloud.google.com/appengine/docs/standard/go111/googlecloudstorageclient/read-write-to-cloud-storage
+https://github.com/GoogleCloudPlatform/golang-samples/blob/8deb2909eadf32523007fd8fe9e8755a12c6d463/docs/appengine/storage/app.go
+*/
 func readJsons() string {
 	fmt.Println("This is a readJsons test...")
 
-	bucket := os.Getenv("BUCKET")
+	bucketName := os.Getenv("BUCKET")
 
 	// Initialize/Connect the Client
 	ctx := context.Background()
@@ -27,23 +30,52 @@ func readJsons() string {
 	ctx, cancel := context.WithTimeout(ctx, time.Second*50)
 	defer cancel()
 
-	// TODO
-	// 1 List all files for bucket...
+	// Prepare bucket handle
+	bucketHandle := client.Bucket(bucketName)
 
-	// 2. iterate through each and add to global...
+	// lists the contents of a bucket in Google Cloud Storage.
+	query := &storage.Query{Prefix: "event"}
+	it := bucketHandle.Objects(ctx, query)
+	for {
+		obj, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			log.Fatal("listBucket: unable to list bucket %q: %v", bucketHandle, err)
+		}
+		printObj(obj)
+		// fmt.Println(">>>>> obj", obj)
+		// d.dumpStats(obj)
+	}
 
-	file := database
-	fmt.Println("DATASET file", file)
-	rc, err := client.Bucket(bucket).Object(file).NewReader(ctx)
-	if err != nil {
-		log.Fatalln("NewReader:", err)
-	}
-	byteValue, _ := ioutil.ReadAll(rc) // jsonFile
-	// defer jsonFile.Close()
-	events := make([]EventJson, 0)
-	if err := json.Unmarshal(byteValue, &events); err != nil {
-		panic(err)
-	}
+	// read each file content
+	// file := database
+	// fmt.Println("DATASET file", file)
+	// rc, err := client.Bucket(bucket).Object(file).NewReader(ctx)
+	// if err != nil {
+	// 	log.Fatalln("NewReader:", err)
+	// }
+	// byteValue, _ := ioutil.ReadAll(rc) // jsonFile
+	// // defer jsonFile.Close()
+	// events := make([]EventJson, 0)
+	// if err := json.Unmarshal(byteValue, &events); err != nil {
+	// 	panic(err)
+	// }
 
 	return "read those jsons"
+}
+
+func printObj(obj *storage.ObjectAttrs) {
+	fmt.Printf("(filename: /%v/%v, \n", obj.Bucket, obj.Name)
+	// fmt.Printf("ContentType: %q, ", obj.ContentType)
+	// fmt.Printf("ACL: %#v, ", obj.ACL)
+	// fmt.Printf("Owner: %v, ", obj.Owner)
+	// fmt.Printf("ContentEncoding: %q, ", obj.ContentEncoding)
+	// fmt.Printf("Size: %v, ", obj.Size)
+	// fmt.Printf("MD5: %q, ", obj.MD5)
+	// fmt.Printf("CRC32C: %q, ", obj.CRC32C)
+	// fmt.Printf("Metadata: %#v, ", obj.Metadata)
+	// fmt.Printf("MediaLink: %q, ", obj.MediaLink)
+	// fmt.Printf("StorageClass: %q, ", obj.StorageClass)
 }

--- a/read-jsons.go
+++ b/read-jsons.go
@@ -72,24 +72,30 @@ func readJsons() string {
 	}
 
 	fmt.Println(">>>>> events []EventJson", len(events))
-	for _, e := range events {
+	for _, event := range events {
 		// match DSN based on js vs python
-		// decide Errors vs Transaction. if error.... make an Error struct. if transaction.... make a Transaction struct.... call methods on both
-		// if e.Type == "error" {
+		if event.Type == "error" {
+			fmt.Println("> error")
+			eventError := Error{event.EventId, event.Release, event.User, event.Timestamp}
+			eventError.eventId()
+			eventError.release()
+			eventError.user()
+			eventError.setTimestamp()
+		}
+		if event.Type == "transaction" {
+			fmt.Println("> transaction")
+			eventTransaction := Transaction{event.EventId, event.Release, event.User, event.Timestamp}
+			eventTransaction.eventIds()
+			eventTransaction.setReleases()
+			eventTransaction.setUsers()
+			eventTransaction.setTimestamps()
 
-		// }
-		// if e.Type == "transaction" {
+			eventTransaction.sentAt()
+			eventTransaction.removeLengthField()
 
-		// }
+		}
 
-		fmt.Println("> event.eventId", e.EventId)
-		// TODO
-		// assuming Error
-		// event = eventId(event) // would be error.eventId(), error.release(), error.user(), error.timestamp()
-		// event = release(event)
-		// event = user(event)
-		// event = updateTimestamp(event)
-
+		fmt.Println("> event.eventId", event.EventId)
 	}
 
 	return "read those jsons"

--- a/read-jsons.go
+++ b/read-jsons.go
@@ -55,13 +55,12 @@ func readJsons(ignore bool) string {
 		}
 		byteValue, _ := ioutil.ReadAll(rc)
 		var event EventJson
+		// UnmarshalJSON overriden in error.go
 		if err := json.Unmarshal(byteValue, &event); err != nil {
 			panic(err)
 		}
 		events = append(events, event)
 	}
-
-	requests := []Request{}
 
 	for _, event := range events {
 		// TODO match DSN here based on js vs python, call on EventJson?
@@ -77,39 +76,38 @@ func readJsons(ignore bool) string {
 
 			fmt.Println("\n> event_id AFTER", event.Error.EventId)
 			fmt.Println("\n> timestamp AFTER", event.Error.Timestamp)
-			requests = append(requests, Request{
-				EventJson:     event,
-				storeEndpoint: dsnToStoreEndpoint(projectDSNs, event.Error.Platform),
-			})
+			// requests = append(requests, Request{
+			// 	EventJson:     event,
+			// 	storeEndpoint: dsnToStoreEndpoint(projectDSNs, event.Error.Platform),
+			// })
 		}
 		if event.Kind == "transaction" {
 			fmt.Println("> transaction <")
-			event.Transaction.eventIds()
-			event.Transaction.setReleases()
-			event.Transaction.setUsers()
-			event.Transaction.setTimestamps()
+			// event.Transaction.eventIds()
+			// event.Transaction.setReleases()
+			// event.Transaction.setUsers()
+			// event.Transaction.setTimestamps()
 
-			event.Transaction.sentAt()
-			event.Transaction.removeLengthField()
+			// event.Transaction.sentAt()
+			// event.Transaction.removeLengthField()
 
-			requests = append(requests, Request{
-				EventJson:     event,
-				storeEndpoint: dsnToStoreEndpoint(projectDSNs, event.Error.Platform),
-			})
+			// requests = append(requests, Request{
+			// 	EventJson:     event,
+			// 	storeEndpoint: dsnToStoreEndpoint(projectDSNs, event.Error.Platform),
+			// })
 		}
-
-		// TODO 6:29P ****
-		// requests := newRequests(events)
 
 		// TODO can run once here `requests = append(requests, Request{` instead of inside Error as well as Transaction if-then block
 	}
 
-	// TODO - could take events[] from here and call event.send() on each...and in there do the request thing...?
-	// i.e. put the 'Request' as an embedded struct type on the EventJson ;)
+	// i.e. put the 'Request' as an embedded struct type on the EventJson ;)??
 
-	// TODO requests.send()
-	sendRequests(requests, ignore)
+	// TODO double check it's object was updated reference `fmt.Println("\n> timestamp AFTER", event.Error.Timestamp)`
+	requests := Requests{events}
+	requests.send()
+
 	return "\n DONE \n"
+	// sendRequests(requests, ignore) // deprecate
 }
 
 func printObj(obj *storage.ObjectAttrs) {

--- a/request.go
+++ b/request.go
@@ -29,7 +29,7 @@ func NewRequest(event EventJson) *Request {
 	}
 	if event.Kind == "transaction" {
 		r.StoreEndpoint = dsnToStoreEndpoint(projectDSNs, event.Transaction.Platform)
-
+		// fmt.Printf("****** event.Transaction %s ******", event.Transaction)
 		bodyBytes, errBodyBytes := json.Marshal(event.Transaction)
 		if errBodyBytes != nil {
 			fmt.Println(errBodyBytes)

--- a/request.go
+++ b/request.go
@@ -1,0 +1,5 @@
+package main
+
+type Request struct {
+	event EventJson
+}

--- a/request.go
+++ b/request.go
@@ -26,10 +26,12 @@ func (r Request) sendRequest() bool {
 	if errNewRequest != nil {
 		log.Fatalln(errNewRequest)
 	}
-	// eventHeaders := [2]string{"content-type", "x-sentry-auth"}
+	// fmt.Printf("*** storeEndpoint *** %v\n", r.storeEndpoint)
+	fmt.Printf("\n*** storeEndpoint *** %v\n", r.storeEndpoint)
+	fmt.Printf("*** x-sentry-auth *** %v\n", os.Getenv("SENTRY_AUTH_KEY"))
+
 	request.Header.Set("content-type", "application/json")
-	fmt.Printf("*** SENTRY_AUTH_KEY ***\n", os.Getenv("SENTRY_AUTH_KEY"))
-	request.Header.Set("x-sentry-auth", os.Getenv("SENTRY_AUTH_KEY"))
+	// request.Header.Set("x-sentry-auth", os.Getenv("SENTRY_AUTH_KEY"))
 
 	// for _, key := range eventHeaders {
 	// // if key != "x-Sentry-Auth" {

--- a/request.go
+++ b/request.go
@@ -66,3 +66,12 @@ func sendRequests(requests []Request, ignore bool) bool {
 	}
 	return true
 }
+
+// TODO rename file to requests.send() ?
+// has access to event and storeEndpoint, so could do call dsnToStoreEndpoint() from here...
+// iterates through `for event := range requests.events`
+// request = Request{
+// 	EventJson:     event,
+// 	storeEndpoint: dsnToStoreEndpoint(projectDSNs, event.Error.Platform),
+// })
+//request.send()

--- a/request.go
+++ b/request.go
@@ -7,19 +7,19 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"os"
 	"time"
 )
 
 type Request struct {
-	errorPayload       Error
+	EventJson
 	transactionPayload Transaction
 	storeEndpoint      string
 }
 
 func (r Request) sendRequest(ignore bool) bool {
 
-	bodyBytes, errBodyBytes := json.Marshal(r.errorPayload)
+	// bodyBytes, errBodyBytes := json.Marshal(r.errorPayload)
+	bodyBytes, errBodyBytes := json.Marshal(r.Error)
 	if errBodyBytes != nil {
 		fmt.Println(errBodyBytes)
 	}
@@ -28,12 +28,16 @@ func (r Request) sendRequest(ignore bool) bool {
 		log.Fatalln(errNewRequest)
 	}
 
-	request.Header.Set("x-sentry-auth", os.Getenv("SENTRY_AUTH_KEY"))
-	request.Header.Set("content-type", "application/json")
+	// TODO 12;33p if both appearing, then don't need this:
+	// request.Header.Set("x-sentry-auth", os.Getenv("SENTRY_AUTH_KEY"))
+	// fmt.Printf("\n> x-sentry-auth %v\n", os.Getenv("SENTRY_AUTH_KEY"))
 
-	fmt.Printf("\n> x-sentry-auth %v\n", os.Getenv("SENTRY_AUTH_KEY"))
+	request.Header.Set("content-type", "application/json")
 	fmt.Printf("\n> storeEndpoint %v\n", r.storeEndpoint)
-	fmt.Printf("\n> errorPayload %+v \n", r.errorPayload)
+
+	// TODO remove this, b/c using UnmarshalJSON
+	// fmt.Printf("\n> errorPayload %+v \n", r.errorPayload)
+	fmt.Printf("\n> errorPayload %+v \n", r.Error)
 
 	if !ignore {
 		response, requestErr := httpClient.Do(request)

--- a/request.go
+++ b/request.go
@@ -18,7 +18,6 @@ type Request struct {
 func NewRequest(event EventJson) *Request {
 	r := new(Request)
 	if event.Kind == "error" {
-		// fmt.Println("\n> timestamp AFTER 2", event.Error.Timestamp)
 		r.StoreEndpoint = dsnToStoreEndpoint(projectDSNs, event.Error.Platform)
 
 		bodyBytes, errBodyBytes := json.Marshal(event.Error)
@@ -29,28 +28,19 @@ func NewRequest(event EventJson) *Request {
 	}
 	if event.Kind == "transaction" {
 		r.StoreEndpoint = dsnToStoreEndpoint(projectDSNs, event.Transaction.Platform)
-		// fmt.Printf("****** event.Transaction %s ******", event.Transaction)
 		bodyBytes, errBodyBytes := json.Marshal(event.Transaction)
 		if errBodyBytes != nil {
 			fmt.Println(errBodyBytes)
 		}
 		r.Payload = bodyBytes
 	}
-	// TODO `r.Payload = bodyBytes` here
+	// TODO move `r.Payload = bodyBytes` to down here
 	// TODO check if either Payload or StoreEndpoint are nil
 	// log.Fatal("unrecognized event.Kind", event.Kind)
 	return r
 }
 
 func (r Request) send() bool {
-
-	// DEPRECATING (moved this to NewRequest)
-	// bodyBytes, errBodyBytes := json.Marshal(r.errorPayload)
-	// bodyBytes, errBodyBytes := json.Marshal(r.Error)
-	// if errBodyBytes != nil {
-	// 	fmt.Println(errBodyBytes)
-	// }
-
 	request, errNewRequest := http.NewRequest("POST", r.StoreEndpoint, bytes.NewReader(r.Payload)) // &buf
 	if errNewRequest != nil {
 		log.Fatalln(errNewRequest)
@@ -59,9 +49,7 @@ func (r Request) send() bool {
 	request.Header.Set("content-type", "application/json")
 
 	fmt.Printf("\n> storeEndpoint %v\n", r.StoreEndpoint)
-	// fmt.Printf("\n> errorPayload %+v \n", r.Payload)
 
-	// fmt.Print("XXXXXX Value of ignore XXXXXXX", ignore)
 	if *ignore == false {
 		response, requestErr := httpClient.Do(request)
 		if requestErr != nil {
@@ -81,26 +69,8 @@ func (r Request) send() bool {
 // DEPRECATING...
 func sendRequests(requests []Request) bool {
 	for _, request := range requests {
-		// if !ignore {
 		request.send()
-		// } else {
-		// fmt.Printf("> %s event IGNORED \n", request.storeEndpoint)
-		// }
 		time.Sleep(750 * time.Millisecond)
 	}
 	return true
 }
-
-// request = Request{
-// 	EventJson:     event,
-// 	storeEndpoint: dsnToStoreEndpoint(projectDSNs, event.Error.Platform), // TODO move to Request constructor
-// })
-
-// request = Request{
-// 	EventJson:     event,
-// 	storeEndpoint: dsnToStoreEndpoint(projectDSNs, event.Transaction.Platform), // TODO move to Request constructor
-// })
-
-// TODO 12;33p since both events are appearing, then don't need this:
-// request.Header.Set("x-sentry-auth", os.Getenv("SENTRY_AUTH_KEY"))
-// fmt.Printf("\n> x-sentry-auth %v\n", os.Getenv("SENTRY_AUTH_KEY"))

--- a/request.go
+++ b/request.go
@@ -1,5 +1,56 @@
 package main
 
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+)
+
 type Request struct {
-	event EventJson
+	errorPayload       Error
+	transactionPayload Transaction
+	storeEndpoint      string
+}
+
+func (r Request) sendRequest() bool {
+
+	bodyBytes, errBodyBytes := json.Marshal(r.errorPayload)
+	if errBodyBytes != nil {
+		fmt.Println(errBodyBytes)
+	}
+	request, errNewRequest := http.NewRequest("POST", r.storeEndpoint, bytes.NewReader(bodyBytes)) // &buf
+	if errNewRequest != nil {
+		log.Fatalln(errNewRequest)
+	}
+	// eventHeaders := [2]string{"content-type", "x-sentry-auth"}
+	request.Header.Set("content-type", "application/json")
+	fmt.Printf("*** SENTRY_AUTH_KEY ***\n", os.Getenv("SENTRY_AUTH_KEY"))
+	request.Header.Set("x-sentry-auth", os.Getenv("SENTRY_AUTH_KEY"))
+
+	// for _, key := range eventHeaders {
+	// // if key != "x-Sentry-Auth" {
+	// request.Header.Set(key, "asdf")
+	// // }
+	// }
+	response, requestErr := httpClient.Do(request)
+	if requestErr != nil {
+		log.Fatal(requestErr)
+	}
+	responseData, responseDataErr := ioutil.ReadAll(response.Body)
+	if responseDataErr != nil {
+		log.Fatal(responseDataErr)
+	}
+	fmt.Printf("> KIND|RESPONSE: %s \n", string(responseData))
+	return true
+}
+
+func sendRequests(requests []Request) bool {
+	for _, request := range requests {
+		request.sendRequest()
+	}
+	return true
 }

--- a/requests.go
+++ b/requests.go
@@ -1,0 +1,17 @@
+package main
+
+type Requests struct {
+	events []EventJson
+}
+
+func (r *Requests) send() {
+	for _, event := range r.events {
+		request := NewRequest(event)
+		request.send()
+	}
+}
+
+// Don't need because can `requests := Requests{events}``
+// func NewRequests(events []EventJson) Requests {
+// 	return Requests{events}
+// }

--- a/requests.go
+++ b/requests.go
@@ -10,8 +10,3 @@ func (r *Requests) send() {
 		request.send()
 	}
 }
-
-// Don't need because can `requests := Requests{events}``
-// func NewRequests(events []EventJson) Requests {
-// 	return Requests{events}
-// }

--- a/timestamps.go
+++ b/timestamps.go
@@ -31,7 +31,7 @@ TRANSACTIONS. body.contexts.trace.span_id is the Parent Trace. start/end here is
 To see a full span `firstSpan := body["spans"].([]interface{})[0].(map[string]interface{})``
 7 decimal places as the range sent by sdk's is 4 to 7
 https://www.epochconverter.com/
-Float form is like 1.5914674155654302e+09
+Float form is 1.5914674155654302e+09
 */
 
 // Errors

--- a/transaction.go
+++ b/transaction.go
@@ -6,4 +6,6 @@ type Transaction struct {
 	User      map[string]interface{} `json:"user"`
 	Timestamp float64                `json:"timestamp"`
 	// Type      string                 `json:"type"`
+
+	Platform string `json:"platform"`
 }

--- a/transaction.go
+++ b/transaction.go
@@ -4,6 +4,6 @@ type Transaction struct {
 	EventId   string                 `json:"event_id"`
 	Release   string                 `json:"release"`
 	User      map[string]interface{} `json:"user"`
-	Timestamp int64                  `json:"timestamp"`
+	Timestamp float64                `json:"timestamp"`
 	// Type      string                 `json:"type"`
 }

--- a/transaction.go
+++ b/transaction.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -76,3 +77,32 @@ func (t *Transaction) eventId() {
 	// 2 update each
 
 }
+
+// setting here, and tag may get value from it?
+func (t *Transaction) release() {
+	date := time.Now()
+	month := date.Month()
+	day := date.Day()
+	var week int
+	switch {
+	case day <= 7:
+		week = 1
+	case day >= 8 && day <= 14:
+		week = 2
+	case day >= 15 && day <= 21:
+		week = 3
+	case day >= 22:
+		week = 4
+	}
+	release := fmt.Sprint(int(month), ".", week)
+	t.Release = release
+}
+
+func (t *Transaction) user() {
+	t.User = make(map[string]interface{})
+	user := t.User
+	user["email"] = createUser()
+}
+
+// not seeing 'sent_at sentAt' property on post-ingest transaction (it was on the pre-ingest tx), so not defining func (t *Transaction) sentAt()
+// not seeing 'length        ' property on post-ingest transaction (it was on the pre-ingest tx), so not defining func (t *Transaction) sentAt()

--- a/transaction.go
+++ b/transaction.go
@@ -1,11 +1,78 @@
 package main
 
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
 type Transaction struct {
 	EventId   string                 `json:"event_id"`
 	Release   string                 `json:"release"`
 	User      map[string]interface{} `json:"user"`
 	Timestamp float64                `json:"timestamp"`
-	// Type      string                 `json:"type"`
+	Type      string                 `json:"type"`
+	Platform  string                 `json:"platform"`
 
-	Platform string `json:"platform"`
+	Project int        `json:"project"`
+	Message string     `json:"message"`
+	Tags    [][]string `json:"tags"`
+
+	Breadcrumbs map[string]interface{} `json:"breadcrumbs"`
+	Contexts    map[string]interface{} `json:"contexts"`
+	Culprit     string                 `json:"culprit"`
+
+	Environment string `json:"environment"`
+
+	Extra map[string]interface{} `json:"extra"`
+
+	Grouping_config map[string]interface{} `json:"grouping_config"` // nothing new but also no processing error warnings
+
+	Key_id string `json:"key_id"`
+	Level  string `json:"level"`
+	Logger string `json:"logger"`
+
+	Metadata map[string]interface{} `json:"metadata"`
+	Received float64                `json:"received"`
+	Request  map[string]interface{} `json:"request"`
+
+	Sdk map[string]interface{} `json:"sdk"`
+
+	Version string `json:"version"`
+
+	Spans []map[string]interface{} `json:"spans"`
+
+	Start_timestamp float64 `json:"start_timestamp"`
+	// Title           string  `json:"title"` 'discarded attribute'
+	Transaction string `json:"transaction"`
+}
+
+func (t *Transaction) eventId() {
+
+	// if _, ok := t.EventId; !ok {
+	// 	log.Print("no event_id on object from DB")
+	// }
+
+	var uuid4 = strings.ReplaceAll(uuid.New().String(), "-", "")
+	t.EventId = uuid4
+	fmt.Println("\n******** event_id updated *********", t.EventId)
+
+	// LOOKING like only 1 event_id in the *transctino.json file ;)
+	/*
+		func eventIds(envelopeItems []interface{}) []interface{} {
+			var uuid4 = strings.ReplaceAll(uuid.New().String(), "-", "")
+			for _, item := range envelopeItems {
+				eventId := item.(map[string]interface{})["event_id"]
+				if eventId != nil {
+					fmt.Println("\n> event_id eventIds", uuid4)
+					item.(map[string]interface{})["event_id"] = uuid4
+				}
+			}
+			return envelopeItems
+		}*/
+
+	// 1 find where in the event-1-*transaction.json's there are eventId's
+	// 2 update each
+
 }

--- a/transaction.go
+++ b/transaction.go
@@ -1,0 +1,9 @@
+package main
+
+type Transaction struct {
+	EventId   string                 `json:"event_id"`
+	Release   string                 `json:"release"`
+	User      map[string]interface{} `json:"user"`
+	Timestamp int64                  `json:"timestamp"`
+	// Type      string                 `json:"type"`
+}

--- a/transaction.go
+++ b/transaction.go
@@ -53,32 +53,8 @@ type Transaction struct {
 }
 
 func (t *Transaction) eventId() {
-
-	// if _, ok := t.EventId; !ok {
-	// 	log.Print("no event_id on object from DB")
-	// }
-
 	var uuid4 = strings.ReplaceAll(uuid.New().String(), "-", "")
 	t.EventId = uuid4
-	// fmt.Println("\n******** event_id updated *********", t.EventId)
-
-	// LOOKING like only 1 event_id in the *transctino.json file ;)
-	/*
-		func eventIds(envelopeItems []interface{}) []interface{} {
-			var uuid4 = strings.ReplaceAll(uuid.New().String(), "-", "")
-			for _, item := range envelopeItems {
-				eventId := item.(map[string]interface{})["event_id"]
-				if eventId != nil {
-					fmt.Println("\n> event_id eventIds", uuid4)
-					item.(map[string]interface{})["event_id"] = uuid4
-				}
-			}
-			return envelopeItems
-		}*/
-
-	// 1 find where in the event-1-*transaction.json's there are eventId's
-	// 2 update each
-
 }
 
 // setting here, and tag may get value from it?
@@ -108,31 +84,12 @@ func (t *Transaction) user() {
 }
 
 func (t *Transaction) timestamps() {
-	/*unixTimestamp := fmt.Sprint(time.Now().Unix())
-	decimalTimestamp, err1 := decimal.NewFromString(unixTimestamp[:10] + "." + unixTimestamp[10:])
-	// fmt.Print("> decimalTimestamp\n", decimalTimestamp)
-	if err1 != nil {
-		log.Fatal(err1)
-	}
-	timestamp, err2 := decimalTimestamp.Round(7).Float64()
-	if err2 == false {
-		log.Fatal(err2)
-	}
-	t.Timestamp = timestamp*/
-
 	// fmt.Printf("\n> updateTimestamps PARENT start_timestamp before %v (%T) ", t.Start_timestamp, t.Start_timestamp)
 	// fmt.Printf("\n> updateTimestamps PARENT       timestamp before %v (%T) \n", t.Timestamp, t.Timestamp)
 
 	if t.Timestamp != 0 && t.Start_timestamp != 0 {
 		var parentStartTimestamp, parentEndTimestamp decimal.Decimal
 		if t.Platform == "python" {
-			// parentStart, _ := time.Parse(time.RFC3339Nano, fmt.Sprintf("%f", t.Start_timestamp))
-			// parentEnd, _ := time.Parse(time.RFC3339Nano, fmt.Sprintf("%f", t.Timestamp))
-			// parentStartTime := fmt.Sprint(parentStart.UnixNano())
-			// parentEndTime := fmt.Sprint(parentEnd.UnixNano())
-			// parentStartTimestamp, _ = decimal.NewFromString(parentStartTime[:10] + "." + parentStartTime[10:])
-			// parentEndTimestamp, _ = decimal.NewFromString(parentEndTime[:10] + "." + parentEndTime[10:])
-
 			parentStartTimestamp = decimal.NewFromFloat(t.Start_timestamp)
 			parentEndTimestamp = decimal.NewFromFloat(t.Timestamp)
 		}
@@ -169,21 +126,7 @@ func (t *Transaction) timestamps() {
 			// fmt.Printf("\n> updatetimestamps SPAN start_timestamp before %v (%T)", span["start_timestamp"].(float64), span["start_timestamp"])
 			// fmt.Printf("\n> updatetimestamps SPAN       timestamp before %v (%T)\n", span["timestamp"].(float64), span["timestamp"])
 
-			// st := fmt.Sprintf("%f", span["start_timestamp"].(float64))
-			// s := fmt.Sprintf("%f", span["timestamp"].(float64))
-			// fmt.Println("> st ", st)
-			// fmt.Println("> s ", s)
-
 			if t.Platform == "python" {
-				// spanStart, _ := time.Parse(time.RFC3339Nano, fmt.Sprintf("%f", span["start_timestamp"].(float64)))
-				// spanEnd, _ := time.Parse(time.RFC3339Nano, fmt.Sprintf("%f", span["timestamp"].(float64)))
-				// fmt.Println("> spanStart", spanStart)
-				// fmt.Println("> spanEnd", spanEnd)
-				// spanStartTime := fmt.Sprint(spanStart.UnixNano())
-				// spanEndTime := fmt.Sprint(spanEnd.UnixNano())
-				// spanStartTimestamp, _ = decimal.NewFromString(spanStartTime[:10] + "." + spanStartTime[10:])
-				// spanEndTimestamp, _ = decimal.NewFromString(spanEndTime[:10] + "." + spanEndTime[10:])
-
 				spanStartTimestamp = decimal.NewFromFloat(span["start_timestamp"].(float64))
 				spanEndTimestamp = decimal.NewFromFloat(span["timestamp"].(float64))
 			}

--- a/transaction.go
+++ b/transaction.go
@@ -169,10 +169,11 @@ func (t *Transaction) timestamps() {
 			var spanStartTimestamp, spanEndTimestamp decimal.Decimal
 			// fmt.Printf("\n> updatetimestamps SPAN start_timestamp before %v (%T)", span["start_timestamp"].(float64), span["start_timestamp"])
 			// fmt.Printf("\n> updatetimestamps SPAN       timestamp before %v (%T)\n", span["timestamp"].(float64), span["timestamp"])
-			st := fmt.Sprintf("%f", span["start_timestamp"].(float64))
-			s := fmt.Sprintf("%f", span["timestamp"].(float64))
-			fmt.Println("> st ", st)
-			fmt.Println("> s ", s)
+
+			// st := fmt.Sprintf("%f", span["start_timestamp"].(float64))
+			// s := fmt.Sprintf("%f", span["timestamp"].(float64))
+			// fmt.Println("> st ", st)
+			// fmt.Println("> s ", s)
 
 			if t.Platform == "python" {
 				// spanStart, _ := time.Parse(time.RFC3339Nano, fmt.Sprintf("%f", span["start_timestamp"].(float64)))
@@ -209,8 +210,8 @@ func (t *Transaction) timestamps() {
 			span["start_timestamp"], _ = newSpanStartTimestamp.Round(7).Float64()
 			span["timestamp"], _ = newSpanEndTimestamp.Round(7).Float64()
 
-			fmt.Printf("\n> updatetimestamps SPAN start_timestamp after %v (%T)", decimal.NewFromFloat(span["start_timestamp"].(float64)), span["start_timestamp"])
-			fmt.Printf("\n> updatetimestamps SPAN       timestamp after %v (%T)\n", decimal.NewFromFloat(span["timestamp"].(float64)), span["timestamp"])
+			// fmt.Printf("\n> updatetimestamps SPAN start_timestamp after %v (%T)", decimal.NewFromFloat(span["start_timestamp"].(float64)), span["start_timestamp"])
+			// fmt.Printf("\n> updatetimestamps SPAN       timestamp after %v (%T)\n", decimal.NewFromFloat(span["timestamp"].(float64)), span["timestamp"])
 		}
 	}
 }

--- a/transaction.go
+++ b/transaction.go
@@ -49,7 +49,7 @@ type Transaction struct {
 	Start_timestamp float64 `json:"start_timestamp"`
 	Transaction     string  `json:"transaction"`
 
-	// TODO measurements, extra
+	Measurements map[string]interface{} `json:"measurements"`
 }
 
 func (t *Transaction) eventId() {
@@ -126,7 +126,6 @@ func (t *Transaction) timestamps() {
 	if t.Timestamp != 0 && t.Start_timestamp != 0 {
 		var parentStartTimestamp, parentEndTimestamp decimal.Decimal
 		if t.Platform == "python" {
-			fmt.Print("**** I'M PYTHON ****")
 			// parentStart, _ := time.Parse(time.RFC3339Nano, fmt.Sprintf("%f", t.Start_timestamp))
 			// parentEnd, _ := time.Parse(time.RFC3339Nano, fmt.Sprintf("%f", t.Timestamp))
 			// parentStartTime := fmt.Sprint(parentStart.UnixNano())
@@ -214,10 +213,6 @@ func (t *Transaction) timestamps() {
 			// fmt.Printf("\n> updatetimestamps SPAN       timestamp after %v (%T)\n", decimal.NewFromFloat(span["timestamp"].(float64)), span["timestamp"])
 		}
 	}
-}
-
-func (t *Transaction) traceIds() {
-
 }
 
 // not seeing 'sent_at sentAt' property on post-ingest transaction (it was on the pre-ingest tx), so not defining func (t *Transaction) sentAt()

--- a/transformers.go
+++ b/transformers.go
@@ -198,10 +198,9 @@ func updateTraceIds(events []EventJson) {
 							// TODO then should check if length is gt 0
 							// if len(spans.([]interface{})) > 0 {
 							for _, value := range spans {
-								fmt.Println("\n> SPAN Transaction trace_id BEFORE ", value["trace_id"])
+								// fmt.Println("\n> SPAN Transaction trace_id BEFORE ", value["trace_id"])
 								value["trace_id"] = NEW_TRACE_ID
-								// fmt.Println("> SPAN Transaction trace_id AFTER", item.(map[string]interface{})["spans"].([]interface{})[0].(map[string]interface{})["trace_id"])
-								fmt.Println("> SPAN Transaction trace_id AFTER", event.Transaction.Spans[0]["trace_id"])
+								// fmt.Println("> SPAN Transaction trace_id AFTER", event.Transaction.Spans[0]["trace_id"])
 							}
 							// }
 						}

--- a/transformers.go
+++ b/transformers.go
@@ -70,7 +70,7 @@ func envelopeReleases(envelopeItems []interface{}, platform string, kind string)
 	return envelopeItems
 }
 
-// CalVer-lite
+// CalVer https://calver.org/
 func release(body map[string]interface{}) map[string]interface{} {
 	date := time.Now()
 	month := date.Month()

--- a/transformers.go
+++ b/transformers.go
@@ -134,6 +134,85 @@ func removeLengthField(items []interface{}) []interface{} {
 	return items
 }
 
+func getTraceIds(events []EventJson) {
+	// var traceIds []string
+	for _, event := range events {
+		var contexts map[string]interface{}
+		if event.Kind == "error" {
+			contexts = event.Error.Contexts
+		}
+		if event.Kind == "transaction" {
+			contexts = event.Transaction.Contexts
+		}
+		if contexts != nil {
+			// fmt.Println("> getTraceIds context != nil")
+			if _, found := contexts["trace"]; found {
+				trace := contexts["trace"]
+				trace_id := trace.(map[string]interface{})["trace_id"].(string)
+				if trace_id != "" {
+					// fmt.Println("> getTraceIds trace_id != nil")
+					matched := false
+					for _, value := range traceIds {
+						if trace_id == value {
+							matched = true
+						}
+					}
+					if !matched {
+						traceIds = append(traceIds, trace_id)
+					}
+				}
+			}
+		}
+	}
+	fmt.Println("> getTraceids traceIds", traceIds)
+}
+
+func updateTraceIds(events []EventJson) {
+	for _, TRACE_ID := range traceIds {
+		var uuid4 = strings.ReplaceAll(uuid.New().String(), "-", "")
+		NEW_TRACE_ID := uuid4
+
+		for _, event := range events {
+			if event.Kind == "error" {
+				contexts := event.Error.Contexts
+				if contexts != nil {
+					trace := contexts["trace"]
+					if TRACE_ID == trace.(map[string]interface{})["trace_id"] {
+						// fmt.Println("\n> MATCHED Error trace_id BEFORE", trace.(map[string]interface{})["trace_id"])
+						trace.(map[string]interface{})["trace_id"] = NEW_TRACE_ID
+						// fmt.Println("> MATCHED Error trace_id AFTER", transport.bodyError["contexts"].(map[string]interface{})["trace"].(map[string]interface{})["trace_id"].(string))
+					}
+				}
+			}
+			if event.Kind == "transaction" {
+				contexts := event.Transaction.Contexts
+				if contexts != nil {
+					trace := contexts["trace"]
+					if TRACE_ID == trace.(map[string]interface{})["trace_id"] {
+						trace.(map[string]interface{})["trace_id"] = NEW_TRACE_ID
+						//fmt.Println(">   MATCHED Transaction trace_id AFTER", item.(map[string]interface{})["contexts"].(map[string]interface{})["trace"].(map[string]interface{})["trace_id"].(string))
+
+						// TODO should check if 'Spans' field exists. it may have been set to 0 if nothing was unmarshal'd to it
+						if len(event.Transaction.Spans) > 0 {
+							spans := event.Transaction.Spans
+							// TODO then should check if length is gt 0
+							// if len(spans.([]interface{})) > 0 {
+							for _, value := range spans {
+								fmt.Println("\n> SPAN Transaction trace_id BEFORE ", value["trace_id"])
+								value["trace_id"] = NEW_TRACE_ID
+								// fmt.Println("> SPAN Transaction trace_id AFTER", item.(map[string]interface{})["spans"].([]interface{})[0].(map[string]interface{})["trace_id"])
+								fmt.Println("> SPAN Transaction trace_id AFTER", event.Transaction.Spans[0]["trace_id"])
+							}
+							// }
+						}
+					}
+				}
+			}
+		}
+
+	}
+}
+
 func getEnvelopeTraceIds(items []interface{}) {
 	for _, item := range items {
 		contexts := item.(map[string]interface{})["contexts"]

--- a/transformers.go
+++ b/transformers.go
@@ -26,6 +26,7 @@ func eventIds(envelopeItems []interface{}) []interface{} {
 	for _, item := range envelopeItems {
 		eventId := item.(map[string]interface{})["event_id"]
 		if eventId != nil {
+			fmt.Println("\n> event_id eventIds", uuid4)
 			item.(map[string]interface{})["event_id"] = uuid4
 		}
 	}


### PR DESCRIPTION
## Description
New process in place, which gets rid of running the 'proxy' interceptor.

This PR allows you to download the JSON format of an event (post-ingestion) and put that into GCS, so then the Go script can read those and send to Sentry.

Previously, a single JSON Array (one single json file) contained all the transactions+events, and there were envelopes in that.

But now, everything can be sent to the old `/store` endpoint, both Transactions+Events. 

Now using embedded struct in base EventJson, and overriding the UnmarshalJson for that type, so can decide if it's Error or Transaction _while_ you unmarshal it:
```
type EventJson struct {
	TypeSwitch `json:"type"`
	*Error
	*Transaction
}

func (eventJson *EventJson) UnmarshalJSON(data []byte) error {
...
}
```

Web Vitals (measurements) and DB Queries (both from previous PR) are there too.

## Testing
https://sentry.io/organizations/testorg-az/discover/da-react:2b175d8dbc65404a96d8bf21c88ed5e4/?field=title&field=event.type&field=project&field=user.display&field=timestamp&name=All+Events&project=5422148&project=5427415&query=&sort=-timestamp&statsPeriod=24h&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1

https://sentry.io/organizations/testorg-az/discover/da-flask:b22d441f5aec4500a13353d8d12a61b6/?field=title&field=event.type&field=project&field=user.display&field=timestamp&name=All+Events&project=5422148&project=5427415&query=&sort=-timestamp&statsPeriod=24h&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1

https://sentry.io/organizations/testorg-az/discover/da-react:e57681b5deaf47658c1a83d6b1131d16/?field=title&field=event.type&field=project&field=user.display&field=timestamp&name=All+Events&project=5422148&project=5427415&query=&sort=-timestamp&statsPeriod=24h&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1

https://sentry.io/organizations/testorg-az/discover/da-flask:f21ba4891c6b4efdb24016026b3be4e6/?field=title&field=event.type&field=project&field=user.display&field=timestamp&name=All+Events&project=5422148&project=5427415&query=&sort=-timestamp&statsPeriod=24h&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1

https://sentry.io/organizations/testorg-az/discover/da-flask:c4519dc1ea6844979f1cccf727df89d3/?field=title&field=event.type&field=project&field=user.display&field=timestamp&name=All+Events&project=5422148&project=5427415&query=&sort=-timestamp&statsPeriod=24h&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1

https://sentry.io/organizations/testorg-az/discover/da-react:9b11398e1e824df183a418ec659f8faf/?field=title&field=event.type&field=project&field=user.display&field=timestamp&name=All+Events&project=5422148&project=5427415&query=&sort=-timestamp&statsPeriod=24h&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1

## Todo
- deprecate old code, move the EventJson struct to its own file
- randomizing timestamps again, as well as Measurements
