### PR TITLE
Rust support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 all:
-	go build -o bin/main *.go && ./bin/main -n 15 err
+	go build -o bin/main *.go && ./bin/main -n 15 -prefix err
 
 i:
-	go build -o bin/main *.go && ./bin/main -i -n 15 err
+	go build -o bin/main *.go && ./bin/main -i -n 15 -prefix err

--- a/demo_automation.go
+++ b/demo_automation.go
@@ -27,13 +27,13 @@ const DART = "dart"
 const CSHARP = "csharp"
 const ELIXIR = "elixir"
 const PERL = "perl"
-const RUST = "rust"
+const RUST = "native"
 
 // Get events from both Sentry and GCS
 func (d *DemoAutomation) getEvents() []Event {
 	var events []Event
 	events1 := d.getEventsFromSentry()
-	events2 := d.getEventsFromGCS(*filePrefix)
+	events2 := d.getEventsFromGCS()
 	events = append(events, events1...)
 	events = append(events, events2...)
 	return events
@@ -56,7 +56,7 @@ func (d *DemoAutomation) getEventsFromSentry() []Event {
 }
 
 // Gets events from Google Cloud Storage
-func (d *DemoAutomation) getEventsFromGCS(filePrefix string) []Event {
+func (d *DemoAutomation) getEventsFromGCS() []Event {
 	// Initialize/Connect the Client
 	ctx := context.Background()
 	client, err := storage.NewClient(ctx)
@@ -74,7 +74,7 @@ func (d *DemoAutomation) getEventsFromGCS(filePrefix string) []Event {
 
 	var fileNames []string
 
-	query := &storage.Query{Prefix: filePrefix}
+	query := &storage.Query{Prefix: *filePrefix}
 	it := bucketHandle.Objects(ctx, query)
 	for {
 		obj, err := it.Next()

--- a/demo_automation.go
+++ b/demo_automation.go
@@ -27,6 +27,7 @@ const DART = "dart"
 const CSHARP = "csharp"
 const ELIXIR = "elixir"
 const PERL = "perl"
+const RUST = "rust"
 
 // Get events from both Sentry and GCS
 func (d *DemoAutomation) getEvents() []Event {

--- a/discoverAPI.go
+++ b/discoverAPI.go
@@ -29,8 +29,7 @@ type EventMetadata struct {
 func (d DiscoverAPI) latestEventMetadata(org string, n int) []EventMetadata {
 	fmt.Printf("\n> ORG %v\n", org)
 
-	// query := makeQuery([]string{JAVASCRIPT, PYTHON, JAVA, RUBY, GO, NODE, PHP, CSHARP, DART, ELIXIR, PERL, RUST})
-	query := makeQuery([]string{RUST})
+	query := makeQuery([]string{JAVASCRIPT, PYTHON, JAVA, RUBY, GO, NODE, PHP, CSHARP, DART, ELIXIR, PERL, RUST})
 	endpoint := fmt.Sprintf("https://sentry.io/api/0/organizations/%v/eventsv2/?statsPeriod=24h&field=event.type&field=project&field=platform&per_page=%v&query=%v", org, strconv.Itoa(n), query)
 
 	request, _ := http.NewRequest("GET", endpoint, nil)

--- a/discoverAPI.go
+++ b/discoverAPI.go
@@ -29,7 +29,8 @@ type EventMetadata struct {
 func (d DiscoverAPI) latestEventMetadata(org string, n int) []EventMetadata {
 	fmt.Printf("\n> ORG %v\n", org)
 
-	query := makeQuery([]string{JAVASCRIPT, PYTHON, JAVA, RUBY, GO, NODE, PHP, CSHARP, DART, ELIXIR, PERL})
+	// query := makeQuery([]string{JAVASCRIPT, PYTHON, JAVA, RUBY, GO, NODE, PHP, CSHARP, DART, ELIXIR, PERL, RUST})
+	query := makeQuery([]string{RUST})
 	endpoint := fmt.Sprintf("https://sentry.io/api/0/organizations/%v/eventsv2/?statsPeriod=24h&field=event.type&field=project&field=platform&per_page=%v&query=%v", org, strconv.Itoa(n), query)
 
 	request, _ := http.NewRequest("GET", endpoint, nil)

--- a/event.go
+++ b/event.go
@@ -100,6 +100,8 @@ func (event *Event) setDsnGCS() {
 		event.Platform = ELIXIR
 	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == PERL {
 		event.Platform = PERL
+	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == RUST {
+		event.Platform = RUST
 	} else {
 		sentry.CaptureException(errors.New("event.Kind and Type condition not found" + event.Kind))
 		log.Fatalf("setDsnGCS() event Kind and Platform not recognized: %v | %v", event.Kind, event.Platform)
@@ -144,6 +146,8 @@ func (event *Event) setPlatform() {
 		event.Platform = ELIXIR
 	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == PERL {
 		event.Platform = PERL
+	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == RUST {
+		event.Platform = RUST
 	} else {
 		sentry.CaptureException(errors.New("event.Kind and Type condition not found" + event.Kind))
 		log.Fatal("setPlatform() event.Kind and type not recognized " + event.Kind)

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ var (
 	counter    int
 )
 
-// v1.0.2
+// v1.0.3
 func init() {
 	if err := godotenv.Load(); err != nil {
 		log.Print("No .env file found")

--- a/requests.go
+++ b/requests.go
@@ -16,8 +16,6 @@ type Requests struct {
 // Doing each destination one-by-one, gives each org a rest before its API is called again, so don't insert a short Sleep Timeout yet
 func (r *Requests) send() {
 	for _, event := range r.events {
-		// fmt.Println("\nEVENT PLATFORM", event.Platform)
-
 		// CONSIDER check if Destinations array is empty, or do during an init somewhere
 		switch event.Platform {
 		case JAVASCRIPT:

--- a/requests.go
+++ b/requests.go
@@ -86,6 +86,12 @@ func (r *Requests) send() {
 				request := NewRequest(event)
 				request.send()
 			}
+		case RUST:
+			for _, dsn := range config.Destinations.Rust {
+				event.setDsn(dsn)
+				request := NewRequest(event)
+				request.send()
+			}
 		default:
 			sentry.CaptureMessage("unsupported event platform: " + event.Platform)
 			fmt.Printf("\nunrecognized Platform %v\n", event.Platform)

--- a/utils.go
+++ b/utils.go
@@ -105,6 +105,7 @@ type Config struct {
 		Dart       []string `yaml:"dart"`
 		Elixir     []string `yaml:"elixir"`
 		Perl       []string `yaml:"perl"`
+		Rust       []string `yaml:"rust"`
 	}
 }
 


### PR DESCRIPTION
Rust Support added.

#### Note
The platform on all Rust events is `platform.name:native`.

Therefore rust support in this Pull Request is implemented like:
```const RUST := native```

#### Note
For Dart, the JSON's `platform.name` was corrected to `platform.name:dart` instead of `platform.name:other`, before uploading to GCS. Could do same for Rust.

## Files for Adding Language Support
Update the following files:
```
demo_automation.go
discoverAPI.go
event.go
requests.go
utils.go
```
Can streamline this.