### PR TITLE
Top 10 Issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ sales*
 *.yml
 
 events/
+events-errors/

--- a/demo_automation.go
+++ b/demo_automation.go
@@ -79,7 +79,10 @@ func (d *DemoAutomation) getEventsFromGCS() []Event {
 	for {
 		obj, err := it.Next()
 		if err == iterator.Done {
-			sentry.CaptureMessage(fmt.Sprintf("finished retrieving %v file names", len(fileNames)))
+			sentry.ConfigureScope(func(scope *sentry.Scope) {
+				scope.SetTag("files", fmt.Sprint(len(fileNames)))
+			})
+			sentry.CaptureMessage(fmt.Sprintf("finished retrieving files"))
 			break
 		}
 		if err != nil {
@@ -107,7 +110,7 @@ func (d *DemoAutomation) getEventsFromGCS() []Event {
 			panic(err)
 		}
 
-		// TODO may be broken, now that setDsn changed.
+		// event.setPlatform()
 		event.setDsnGCS()
 		event.undertake()
 		events = append(events, event)

--- a/event.go
+++ b/event.go
@@ -158,6 +158,7 @@ func (e Event) undertake() {
 		if e.Error.Tags == nil {
 			e.Error.Tags = make([][]string, 0)
 		}
+		// TODO need to replace the 'demo-automation' element in the array if it exists already, or else you're adding duplicate elements
 		tagItem := []string{"demo-automation", "replay"}
 		e.Error.Tags = append(e.Error.Tags, tagItem)
 	}

--- a/event.go
+++ b/event.go
@@ -103,7 +103,7 @@ func (event *Event) setDsnGCS() {
 		event.Platform = RUST
 	} else {
 		sentry.CaptureException(errors.New("event.Kind and Type condition not found" + event.Kind))
-		log.Fatalf("setDsnGCS() event Kind and Platform not recognized: %v | %v", event.Kind, event.Platform)
+		log.Fatalf("setDsnGCS() event Kind: %v and Platform: %v not recognized", event.Kind, event.Platform)
 	}
 }
 
@@ -149,7 +149,7 @@ func (event *Event) setPlatform() {
 		event.Platform = RUST
 	} else {
 		sentry.CaptureException(errors.New("event.Kind and Type condition not found" + event.Kind))
-		log.Fatal("setPlatform() event.Kind and type not recognized " + event.Kind)
+		log.Fatal("setPlatform() event.Kind and type not recognized " + event.Kind + " " + event.Error.Platform)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func init() {
 
 	ignore = flag.Bool("i", false, "ignore sending the event to Sentry.io")
 	n = flag.Int("n", 25, "default number of events to read from a source")
-	filePrefix = flag.String("prefix", "err", "file prefix")
+	filePrefix = flag.String("prefix", "error", "file prefix")
 	flag.Parse()
 }
 

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ func init() {
 func main() {
 	demoAutomation := DemoAutomation{}
 
-	events := demoAutomation.getEvents()
+	events := demoAutomation.getEventsFromGCS()
 
 	for _, event := range events {
 		if event.Kind == ERROR || event.Kind == DEFAULT {


### PR DESCRIPTION
## Done
- file prefix updated to `error` to separate from previous `err` .json's.
- update cloud and local config.yaml's to not use testorg-az, as that would repeat Cloud Run (TDA) data + Transactions.
- up to 10 issues per platform in GCS. Most are 1 to 5.

## Todo
- is will-captel org still consuming? decommission it from the VM compute engine's config.yaml.
- replace demo-automation tag element in array of tags
- 
## Eval
Stop doing Transactions altogether?