### PR TITLE
Remove Mechanism Minidump

### DIFF
--- a/demo_automation.go
+++ b/demo_automation.go
@@ -114,8 +114,31 @@ func (d *DemoAutomation) getEventsFromGCS() []Event {
 		event.setDsnGCS()
 		event.undertake()
 		events = append(events, event)
+		events = removeMechanism(events)
 	}
 	return events
+}
+
+func removeMechanism(_events []Event) []Event {
+	for _, event := range _events {
+		if event.Kind == ERROR || event.Kind == DEFAULT {
+			exception := event.Error.Exception
+			values := exception["values"]
+			if values != nil {
+				for _, value := range values.([]interface{}) {
+					mechanism := value.(map[string]interface{})["mechanism"]
+					if mechanism != nil {
+						mechanismType := mechanism.(map[string]interface{})["type"]
+						fmt.Println("mechanismType", mechanismType)
+						if mechanismType == "minidump" {
+							delete(value.(map[string]interface{}), "mechanism")
+						}
+					}
+				}
+			}
+		}
+	}
+	return _events
 }
 
 func printObj(obj *storage.ObjectAttrs) {

--- a/eventsAPI.go
+++ b/eventsAPI.go
@@ -50,6 +50,7 @@ func (e EventsAPI) getEvents(org string, eventMetadata []EventMetadata) []Event 
 	}
 	events = sanitize(events)
 	events = fingerprintCheck(events)
+	events = mechanismCheck(events)
 	fmt.Printf("> %v Events length %v\n", org, len(events))
 	return events
 }
@@ -61,6 +62,21 @@ func fingerprintCheck(_events []Event) []Event {
 			// stack.abs_path is different on each (due to static.js/testing being used), thereby creating too many unique issues
 			if metadata["type"] == "AssertionError" && metadata["value"] == "expected 'Error' to equal 'TypeError'" {
 				event.Error.Fingerprint = []string{"assertion-error-expected"}
+			}
+		}
+	}
+	return _events
+}
+func mechanismCheck(_events []Event) []Event {
+	for _, event := range _events {
+		if event.Kind == ERROR || event.Kind == DEFAULT {
+			exception := event.Error.Exception
+			values := Exception.Values
+			for value, _ := range values {
+				mechanism := value.Mechanism
+				if mechanism.Type == "minidump" {
+					// remove event, somehow...
+				}
 			}
 		}
 	}

--- a/eventsAPI.go
+++ b/eventsAPI.go
@@ -48,9 +48,8 @@ func (e EventsAPI) getEvents(org string, eventMetadata []EventMetadata) []Event 
 		event.undertake()
 		events = append(events, event)
 	}
-	events = sanitize(events)
+	events = sanitizeOrg(events)
 	events = fingerprintCheck(events)
-	events = mechanismCheck(events)
 	fmt.Printf("> %v Events length %v\n", org, len(events))
 	return events
 }
@@ -62,21 +61,6 @@ func fingerprintCheck(_events []Event) []Event {
 			// stack.abs_path is different on each (due to static.js/testing being used), thereby creating too many unique issues
 			if metadata["type"] == "AssertionError" && metadata["value"] == "expected 'Error' to equal 'TypeError'" {
 				event.Error.Fingerprint = []string{"assertion-error-expected"}
-			}
-		}
-	}
-	return _events
-}
-func mechanismCheck(_events []Event) []Event {
-	for _, event := range _events {
-		if event.Kind == ERROR || event.Kind == DEFAULT {
-			exception := event.Error.Exception
-			values := Exception.Values
-			for value, _ := range values {
-				mechanism := value.Mechanism
-				if mechanism.Type == "minidump" {
-					// remove event, somehow...
-				}
 			}
 		}
 	}
@@ -101,7 +85,7 @@ func hasOrgTag(event Event) bool {
 	return false
 }
 
-func sanitize(_events []Event) []Event {
+func sanitizeOrg(_events []Event) []Event {
 	var events []Event
 	for _, event := range _events {
 		if hasOrgTag(event) == false {


### PR DESCRIPTION
## Goal
Remove the 'mechanism' object from the event Exception, and still send event to Sentry.io
![image](https://user-images.githubusercontent.com/8920574/105065897-5ed58d00-5a4c-11eb-8ad4-50cc1498c2f1.png)

## Testing
The 'mechanism' is not present on this sentry.native event
https://sentry.io/organizations/will-captel/issues/2164714507/?project=5541775
[JSON](https://sentry.io/organizations/will-captel/issues/2164714507/events/6040e6ed12cd4211bcf6054513015300/json/)
![image](https://user-images.githubusercontent.com/8920574/105070292-11a7ea00-5a51-11eb-8cd8-72c26fe0a35f.png)

before/after logging confirms the same:
```
* * * * * ** * * value BEFORE* ** * * * * ** 
map[handled:false synthetic:true type:minidump]event.Platform native
event.Error.Sdk map[integrations:[crashpad] name:sentry.native packages:[map[name:github:getsentry/sentry-native version:0.4.4]] version:0.4.4]

* * * * * ** * * value AFTER* ** * * * * ** *
```

the tag mechanism:minidump is still present, but this is not known to cause problems.