### PR TITLE
Mobile Errors

### DIFF
--- a/demo_automation.go
+++ b/demo_automation.go
@@ -28,6 +28,8 @@ const CSHARP = "csharp"
 const ELIXIR = "elixir"
 const PERL = "perl"
 const RUST = "native"
+const COCOA = "cocoa"
+const ANDROID = "android"
 
 // Get events from both Sentry and GCS
 func (d *DemoAutomation) getEvents() []Event {

--- a/discoverAPI.go
+++ b/discoverAPI.go
@@ -29,7 +29,7 @@ type EventMetadata struct {
 func (d DiscoverAPI) latestEventMetadata(org string, n int) []EventMetadata {
 	fmt.Printf("\n> ORG %v\n", org)
 
-	query := makeQuery([]string{JAVASCRIPT, PYTHON, JAVA, RUBY, GO, NODE, PHP, CSHARP, DART, ELIXIR, PERL, RUST})
+	query := makeQuery([]string{JAVASCRIPT, PYTHON, JAVA, RUBY, GO, NODE, PHP, CSHARP, DART, ELIXIR, PERL, RUST, COCOA, ANDROID})
 	endpoint := fmt.Sprintf("https://sentry.io/api/0/organizations/%v/eventsv2/?statsPeriod=24h&field=event.type&field=project&field=platform&per_page=%v&query=%v", org, strconv.Itoa(n), query)
 
 	request, _ := http.NewRequest("GET", endpoint, nil)

--- a/dsn.go
+++ b/dsn.go
@@ -18,6 +18,13 @@ type DSN struct {
 }
 
 func NewDSN(rawurl string) *DSN {
+	sentry.ConfigureScope(func(scope *sentry.Scope) {
+		scope.SetTag("dsn", rawurl)
+	})
+
+	if strings.Contains(rawurl, "http") != true || strings.Contains(rawurl, "@") != true {
+		sentry.CaptureException(errors.New("bad DSN key"))
+	}
 	// still need support for http vs. https 7: vs 8:
 	key := strings.Split(rawurl, "@")[0][7:]
 
@@ -48,7 +55,7 @@ func NewDSN(rawurl string) *DSN {
 	// 	log.Fatal("bad key length")
 	// }
 	if len(projectId) != 7 {
-		sentry.CaptureException(errors.New("bad project Id in dsn" + projectId))
+		sentry.CaptureException(errors.New("bad project Id in dsn"))
 		log.Fatal("bad project Id in dsn")
 	}
 	if projectId == "" {

--- a/dsn.go
+++ b/dsn.go
@@ -54,7 +54,7 @@ func NewDSN(rawurl string) *DSN {
 	// if len(key) < 31 || len(key) > 32 {
 	// 	log.Fatal("bad key length")
 	// }
-	if len(projectId) != 7 {
+	if len(projectId) < 6 {
 		sentry.CaptureException(errors.New("bad project Id in dsn"))
 		log.Fatal("bad project Id in dsn")
 	}

--- a/event.go
+++ b/event.go
@@ -101,6 +101,10 @@ func (event *Event) setDsnGCS() {
 		event.Platform = PERL
 	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == RUST {
 		event.Platform = RUST
+	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == COCOA {
+		event.Platform = COCOA
+	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == ANDROID {
+		event.Platform = ANDROID
 	} else {
 		sentry.CaptureException(errors.New("event.Kind and Type condition not found" + event.Kind))
 		log.Fatalf("setDsnGCS() event Kind: %v and Platform: %v not recognized", event.Kind, event.Platform)
@@ -147,6 +151,10 @@ func (event *Event) setPlatform() {
 		event.Platform = PERL
 	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == RUST {
 		event.Platform = RUST
+	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == COCOA {
+		event.Platform = COCOA
+	} else if (event.Kind == ERROR || event.Kind == DEFAULT) && event.Error.Platform == ANDROID {
+		event.Platform = ANDROID
 	} else {
 		sentry.CaptureException(errors.New("event.Kind and Type condition not found" + event.Kind))
 		log.Fatal("setPlatform() event.Kind and type not recognized " + event.Kind + " " + event.Error.Platform)

--- a/main.go
+++ b/main.go
@@ -32,7 +32,9 @@ func init() {
 
 	ignore = flag.Bool("i", false, "ignore sending the event to Sentry.io")
 	n = flag.Int("n", 25, "default number of events to read from a source")
-	filePrefix = flag.String("prefix", "error", "file prefix")
+
+	defaultPrefix := "error-"
+	filePrefix = flag.String("prefix", defaultPrefix, "file prefix")
 	flag.Parse()
 }
 

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func init() {
 	ignore = flag.Bool("i", false, "ignore sending the event to Sentry.io")
 	n = flag.Int("n", 25, "default number of events to read from a source")
 
-	defaultPrefix := "error-"
+	defaultPrefix := "error"
 	filePrefix = flag.String("prefix", defaultPrefix, "file prefix")
 	flag.Parse()
 }

--- a/requests.go
+++ b/requests.go
@@ -87,6 +87,18 @@ func (r *Requests) send() {
 				request := NewRequest(event)
 				request.send()
 			}
+		case COCOA:
+			for _, dsn := range config.Destinations.Cocoa {
+				event.setDsn(dsn)
+				request := NewRequest(event)
+				request.send()
+			}
+		case ANDROID:
+			for _, dsn := range config.Destinations.Android {
+				event.setDsn(dsn)
+				request := NewRequest(event)
+				request.send()
+			}
 		default:
 			sentry.CaptureMessage("unsupported event platform: " + event.Platform)
 			fmt.Printf("\nunrecognized Platform %v\n", event.Platform)

--- a/requests.go
+++ b/requests.go
@@ -10,10 +10,10 @@ type Requests struct {
 	events []Event
 }
 
+// TODO in each case met, should check len(config.Destinations.Platform) != 0
 // Doing each destination one-by-one, gives each org a rest before its API is called again, so don't insert a short Sleep Timeout yet
 func (r *Requests) send() {
 	for _, event := range r.events {
-		// EVAL check if Destinations array is empty, or do during an init somewhere
 		switch event.Platform {
 		case JAVASCRIPT:
 			for _, dsn := range config.Destinations.Javascript {

--- a/utils.go
+++ b/utils.go
@@ -109,6 +109,8 @@ type Config struct {
 		Elixir     []string `yaml:"elixir"`
 		Perl       []string `yaml:"perl"`
 		Rust       []string `yaml:"rust"`
+		Cocoa      []string `yaml:"cocoa"`
+		Android    []string `yaml:"android"`
 	}
 }
 


### PR DESCRIPTION
`cocoa` and `android`

## Notes
changed 'platform' to android in the JSON files, because it was set as 'java' or 'native' sometimes.
```
    "platform": "android",
```

`sdk.name` is still java or 'native' (Messages are 'native').

Also, improved some basic error handling and defaulted the prefix.
```
	sentry.ConfigureScope(func(scope *sentry.Scope) {
		scope.SetTag("dsn", rawurl)
	})
```
## Tested
cocoa  
https://sentry.io/organizations/will-captel/issues/2167906048/?project=-1&query=is%3Aunresolved

android unhandled
https://sentry.io/organizations/testorg-az/issues/2167992934/

android unhandled
https://sentry.io/organizations/testorg-az/issues/2167992925/

android unhandled native crash
https://sentry.io/organizations/testorg-az/issues/2167992950/

android handled 
https://sentry.io/organizations/testorg-az/issues/2167992911/

android anr
https://sentry.io/organizations/testorg-az/issues/2167992899/


## Todo
Update the config.yaml with cocoa and android dsn's.